### PR TITLE
Add sqlite3 to msvc build

### DIFF
--- a/cmake/Modules/FindWinSqlite3.cmake
+++ b/cmake/Modules/FindWinSqlite3.cmake
@@ -1,0 +1,7 @@
+#  - Try to find Sqlite3
+#
+#  SQLITE_INCLUDE_DIRECTORY - the Sqlite3 include directory
+#  SQLITE_LIB_DIRECTORY - the Sqlite3 lib directory
+
+set(SQLITE_INCLUDE_DIRECTORY $ENV{SQLITE_DIR})
+set(SQLITE_LIB_DIRECTORY $ENV{SQLITE_DIR})

--- a/src/components/utils/CMakeLists.txt
+++ b/src/components/utils/CMakeLists.txt
@@ -53,7 +53,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
 			${UTILS_SRC_DIR}/threads/win_thread.cc
     )
 
-#    add_subdirectory(./src/sqlite_wrapper)
+    add_subdirectory(./src/sqlite_wrapper)
     string( REPLACE / \\ group ${inc} )
     source_group("Header Files" FILES ${inc} )
     string( REPLACE / \\ group ${src} )

--- a/src/components/utils/src/sqlite_wrapper/CMakeLists.txt
+++ b/src/components/utils/src/sqlite_wrapper/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2013, Ford Motor Company
+# Copyright (c) 2015, Ford Motor Company
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -30,9 +30,16 @@
 
 set(target dbms)
 
-find_package(Sqlite3 REQUIRED)
+if (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+  find_package(WinSqlite3 REQUIRED)
+else()
+  find_package(Sqlite3 REQUIRED)
+endif()
 
-include_directories(${COMPONENTS_DIR}/utils/include/utils)
+include_directories(
+  ${COMPONENTS_DIR}/utils/include/utils
+  ${SQLITE_INCLUDE_DIRECTORY}
+)
 
 set(SOURCES
   ./sql_database.cc

--- a/src/components/utils/src/sqlite_wrapper/sql_query.cc
+++ b/src/components/utils/src/sqlite_wrapper/sql_query.cc
@@ -53,7 +53,8 @@ bool SQLQuery::Prepare(const std::string& query) {
   Finalize();
   sync_primitives::AutoLock auto_lock(statement_lock_);
   if (statement_) return false;
-  error_ = sqlite3_prepare(db_.conn(), query.c_str(), query.length(),
+  error_ = sqlite3_prepare(db_.conn(), query.c_str(),
+                           static_cast<int>(query.length()),
                            &statement_, NULL);
   query_ = query;
   return error_ == SQLITE_OK;
@@ -109,12 +110,13 @@ void SQLQuery::Bind(int pos, bool value) {
 
 void SQLQuery::Bind(int pos, const std::string& value) {
   // In SQLite the number of position for binding starts since 1.
-  error_ = sqlite3_bind_text(statement_, pos + 1, value.c_str(), value.length(),
-  SQLITE_TRANSIENT);
+  error_ = sqlite3_bind_text(statement_, pos + 1, value.c_str(),
+                             static_cast<int>(value.length()),
+                             SQLITE_TRANSIENT);
 }
 
 bool SQLQuery::GetBoolean(int pos) const {
-  return static_cast<bool>(GetInteger(pos));
+  return GetInteger(pos) != 0;
 }
 
 int SQLQuery::GetInteger(int pos) const {


### PR DESCRIPTION
- Change cmake files to include sqlite3 headers
- Fix sqlite_wrapper build

Sqlite3 library should be installed and environment variable SQLITE_DIR point to
Sqlite3 directory
