### PR TITLE
Remove Profile singleton using from Policy library

### DIFF
--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -333,7 +333,7 @@ bool PolicyHandler::PolicyEnabled() {
 }
 
 bool PolicyHandler::CreateManager() {
-  typedef PolicyManager* (*CreateManager)();
+  typedef PolicyManager* (*CreateManager)(const std::string&, uint16_t, uint16_t);
 #if defined(OS_POSIX)
   CreateManager create_manager =
       reinterpret_cast<CreateManager>(dlsym(dl_handle_, "CreateManager"));
@@ -347,7 +347,10 @@ bool PolicyHandler::CreateManager() {
   CreateManager create_manager =
       reinterpret_cast<CreateManager>(GetProcAddress(dl_handle_, "CreateManager"));
   if (create_manager != NULL) {
-    policy_manager_ = create_manager();
+    policy_manager_ = create_manager(
+        profile::Profile::instance()->app_storage_folder(),
+        profile::Profile::instance()->attempts_to_open_policy_db(),
+        profile::Profile::instance()->open_attempt_timeout_ms());
   } else {
     LOG4CXX_WARN(logger_, "Policy library loading error. Cannot get proc address");
   }

--- a/src/components/include/utils/macro.h
+++ b/src/components/include/utils/macro.h
@@ -121,6 +121,12 @@
 */
 #define GETARRAYSIZE(arr) sizeof (arr) / sizeof(*arr)
 
+#if defined(OS_POSIX)
+#define SDL_DLL_EXPORT extern "C"
+#elif defined(OS_WINDOWS)
+#define SDL_DLL_EXPORT extern "C" __declspec(dllexport)
+#endif
+
 #ifdef BUILD_TESTS
 #define FRIEND_TEST(test_case_name, test_name)\
 friend class test_case_name##_##test_name##_Test

--- a/src/components/include/utils/macro.h
+++ b/src/components/include/utils/macro.h
@@ -105,9 +105,14 @@
 
 #define NOTREACHED() DCHECK(!"Unreachable code")
 
+#if __cplusplus >= 201103L
+#define SDL_CPP11
+#endif
+
 // Allows to perform static check that virtual function from base class is
 // actually being overriden if compiler support is available
-#if __cplusplus >= 201103L
+
+#ifdef SDL_CPP11
 #define OVERRIDE override
 #define FINAL final
 #else

--- a/src/components/include/utils/macro.h
+++ b/src/components/include/utils/macro.h
@@ -122,9 +122,9 @@
 #define GETARRAYSIZE(arr) sizeof (arr) / sizeof(*arr)
 
 #if defined(OS_POSIX)
-#define SDL_DLL_EXPORT extern "C"
+#define SDL_EXPORT extern "C"
 #elif defined(OS_WINDOWS)
-#define SDL_DLL_EXPORT extern "C" __declspec(dllexport)
+#define SDL_EXPORT extern "C" __declspec(dllexport)
 #endif
 
 #ifdef BUILD_TESTS

--- a/src/components/include/utils/threads/thread.h
+++ b/src/components/include/utils/threads/thread.h
@@ -43,6 +43,7 @@
 
 #include <ostream>
 #include <string>
+#include <cstdint>
 
 #include "utils/macro.h"
 #include "utils/threads/thread_delegate.h"
@@ -84,6 +85,7 @@ typedef HANDLE PlatformThreadHandle;
 
 class Thread;
 void enqueue_to_join(Thread* thread);
+void sleep(uint32_t ms);
 
 Thread* CreateThread(const char* name, ThreadDelegate* delegate);
 void DeleteThread(Thread* thread);

--- a/src/components/policy/src/policy/CMakeLists.txt
+++ b/src/components/policy/src/policy/CMakeLists.txt
@@ -53,7 +53,6 @@ include_directories (
   #${CMAKE_CURRENT_BINARY_DIR}
   ${CMAKE_SOURCE_DIR}/src/components/utils/include/
   ${CMAKE_SOURCE_DIR}/src/components
-  ${CMAKE_SOURCE_DIR}/src/components/config_profile/include
   ${LOG4CXX_INCLUDE_DIRECTORY}
 )
 
@@ -75,7 +74,7 @@ add_subdirectory(usage_statistics)
 include_directories(./policy_table/table_struct)
 add_subdirectory(policy_table/table_struct)
 
-set(LIBRARIES ConfigProfile policy_struct dbms jsoncpp Utils)
+set(LIBRARIES policy_struct dbms jsoncpp Utils)
 if (CMAKE_SYSTEM_NAME STREQUAL "QNX")
   # --- QDB Wrapper 
   include_directories (${COMPONENTS_DIR}/utils/include/utils)

--- a/src/components/policy/src/policy/include/policy/cache_manager.h
+++ b/src/components/policy/src/policy/include/policy/cache_manager.h
@@ -50,7 +50,9 @@ namespace policy {
 
 class CacheManager : public CacheManagerInterface {
  public:
-  CacheManager();
+  CacheManager(const std::string& app_storage_folder,
+               uint16_t attempts_to_open_policy_db,
+               uint16_t open_attempt_timeout_ms);
   ~CacheManager();
 
   /**

--- a/src/components/policy/src/policy/include/policy/policy_manager.h
+++ b/src/components/policy/src/policy/include/policy/policy_manager.h
@@ -460,7 +460,7 @@ class PolicyManager : public usage_statistics::StatisticsManager {
 
 }  // namespace policy
 
-SDL_DLL_EXPORT
+SDL_EXPORT
 policy::PolicyManager* CreateManager(
     const std::string& app_storage_folder,
     uint16_t attempts_to_open_policy_db,

--- a/src/components/policy/src/policy/include/policy/policy_manager.h
+++ b/src/components/policy/src/policy/include/policy/policy_manager.h
@@ -459,6 +459,13 @@ class PolicyManager : public usage_statistics::StatisticsManager {
 
 }  // namespace policy
 
-extern "C" policy::PolicyManager* CreateManager();
+#if defined(OS_POSIX)
+extern "C" policy::PolicyManager* CreateManager(
+#elif defined(OS_WINDOWS)
+extern "C" __declspec(dllexport) policy::PolicyManager* CreateManager(
+#endif
+    const std::string& app_storage_folder,
+    uint16_t attempts_to_open_policy_db,
+    uint16_t open_attempt_timeout_ms);
 
 #endif  // SRC_COMPONENTS_POLICY_INCLUDE_POLICY_POLICY_MANAGER_H_

--- a/src/components/policy/src/policy/include/policy/policy_manager.h
+++ b/src/components/policy/src/policy/include/policy/policy_manager.h
@@ -35,6 +35,7 @@
 
 #include <vector>
 
+#include "utils/macro.h"
 #include "policy/policy_types.h"
 #include "policy/policy_listener.h"
 #include "usage_statistics/statistics_manager.h"
@@ -459,11 +460,8 @@ class PolicyManager : public usage_statistics::StatisticsManager {
 
 }  // namespace policy
 
-#if defined(OS_POSIX)
-extern "C" policy::PolicyManager* CreateManager(
-#elif defined(OS_WINDOWS)
-extern "C" __declspec(dllexport) policy::PolicyManager* CreateManager(
-#endif
+SDL_DLL_EXPORT
+policy::PolicyManager* CreateManager(
     const std::string& app_storage_folder,
     uint16_t attempts_to_open_policy_db,
     uint16_t open_attempt_timeout_ms);

--- a/src/components/policy/src/policy/include/policy/policy_manager_impl.h
+++ b/src/components/policy/src/policy/include/policy/policy_manager_impl.h
@@ -320,7 +320,7 @@ private:
      */
     std::string last_device_id_;
 
-    bool ignition_check;
+    bool ignition_check_;
 
     const std::string app_storage_folder_;
 

--- a/src/components/policy/src/policy/include/policy/policy_manager_impl.h
+++ b/src/components/policy/src/policy/include/policy/policy_manager_impl.h
@@ -52,7 +52,9 @@ struct CheckAppPolicy;
 
 class PolicyManagerImpl : public PolicyManager {
   public:
-    PolicyManagerImpl();
+   PolicyManagerImpl(const std::string& app_storage_folder,
+                     uint16_t attempts_to_open_policy_db,
+                     uint16_t open_attempt_timeout_ms);
     virtual void set_listener(PolicyListener* listener);
     PolicyListener* listener() const {
       return listener_;
@@ -319,6 +321,8 @@ private:
     std::string last_device_id_;
 
     bool ignition_check;
+
+    const std::string app_storage_folder_;
 
     friend struct CheckAppPolicy;
 };

--- a/src/components/policy/src/policy/include/policy/policy_table.h
+++ b/src/components/policy/src/policy/include/policy/policy_table.h
@@ -41,7 +41,9 @@ namespace policy {
 
 class PolicyTable {
  public:
-  PolicyTable();
+  PolicyTable(const std::string& app_storage_folder,
+              uint16_t attempts_to_open_policy_db,
+              uint16_t open_attempt_timeout_ms);
   explicit PolicyTable(utils::SharedPtr<PTRepresentation> pt_data);
   virtual ~PolicyTable();
 

--- a/src/components/policy/src/policy/include/policy/sql_pt_representation.h
+++ b/src/components/policy/src/policy/include/policy/sql_pt_representation.h
@@ -52,7 +52,9 @@ namespace policy {
 
 class SQLPTRepresentation : public virtual PTRepresentation {
   public:
-    SQLPTRepresentation();
+    SQLPTRepresentation(const std::string& app_storage_folder,
+                        uint16_t attempts_to_open_policy_db,
+                        uint16_t open_attempt_timeout_ms);
     ~SQLPTRepresentation();
     virtual void CheckPermissions(const PTString& app_id,
         const PTString& hmi_level,
@@ -174,6 +176,10 @@ class SQLPTRepresentation : public virtual PTRepresentation {
   private:
     static const std::string kDatabaseName;
     utils::dbms::SQLDatabase* db_;
+
+    const std::string app_storage_folder_;
+    const uint16_t attempts_to_open_policy_db_;
+    const uint16_t open_attempt_timeout_ms_;
 
 #ifdef BUILD_TESTS
     uint32_t open_counter_;

--- a/src/components/policy/src/policy/src/cache_manager.cc
+++ b/src/components/policy/src/policy/src/cache_manager.cc
@@ -82,11 +82,14 @@ private:
   const std::string& language_;
 };
 
-CacheManager::CacheManager()
+CacheManager::CacheManager(const std::string& app_storage_folder,
+                           uint16_t attempts_to_open_policy_db,
+                           uint16_t open_attempt_timeout_ms)
   : CacheManagerInterface(),
     pt_(new policy_table::Table),
     backup_(
-                     new SQLPTRepresentation()
+      new SQLPTRepresentation(
+          app_storage_folder, attempts_to_open_policy_db, open_attempt_timeout_ms)
     ),
     update_required(false) {
 

--- a/src/components/policy/src/policy/src/policy_manager_impl.cc
+++ b/src/components/policy/src/policy/src/policy_manager_impl.cc
@@ -50,7 +50,7 @@ policy::PolicyManager* CreateManager(const std::string& app_storage_folder,
                                      uint16_t attempts_to_open_policy_db,
                                      uint16_t open_attempt_timeout_ms) {
   return new policy::PolicyManagerImpl(
-      app_storage_folder, attempts_to_open_policy_db, open_attempt_timeout_ms);
+    app_storage_folder, attempts_to_open_policy_db, open_attempt_timeout_ms);
 }
 
 namespace policy {
@@ -67,7 +67,7 @@ PolicyManagerImpl::PolicyManagerImpl(const std::string& app_storage_folder,
                             open_attempt_timeout_ms)),
     retry_sequence_timeout_(60),
     retry_sequence_index_(0),
-    ignition_check(true),
+    ignition_check_(true),
     app_storage_folder_(app_storage_folder) {
 }
 
@@ -288,9 +288,9 @@ void PolicyManagerImpl::StartPTExchange() {
   }
 
   if (listener_ && listener_->CanUpdate()) {
-    if (ignition_check) {
+    if (ignition_check_) {
       CheckTriggers();
-      ignition_check = false;
+      ignition_check_ = false;
     }
 
     if (update_status_manager_.IsUpdateRequired()) {

--- a/src/components/policy/src/policy/src/policy_manager_impl.cc
+++ b/src/components/policy/src/policy/src/policy_manager_impl.cc
@@ -45,23 +45,30 @@
 #include "utils/date_time.h"
 #include "policy/cache_manager.h"
 #include "policy/update_status_manager.h"
-#include "config_profile/profile.h"
 
-policy::PolicyManager* CreateManager() {
-  return new policy::PolicyManagerImpl();
+policy::PolicyManager* CreateManager(const std::string& app_storage_folder,
+                                     uint16_t attempts_to_open_policy_db,
+                                     uint16_t open_attempt_timeout_ms) {
+  return new policy::PolicyManagerImpl(
+      app_storage_folder, attempts_to_open_policy_db, open_attempt_timeout_ms);
 }
 
 namespace policy {
 
 CREATE_LOGGERPTR_GLOBAL(logger_, "PolicyManagerImpl")
 
-PolicyManagerImpl::PolicyManagerImpl()
+PolicyManagerImpl::PolicyManagerImpl(const std::string& app_storage_folder,
+                                     uint16_t attempts_to_open_policy_db,
+                                     uint16_t open_attempt_timeout_ms)
   : PolicyManager(),
     listener_(NULL),
-    cache_(new CacheManager),
+    cache_(new CacheManager(app_storage_folder,
+                            attempts_to_open_policy_db,
+                            open_attempt_timeout_ms)),
     retry_sequence_timeout_(60),
     retry_sequence_index_(0),
-    ignition_check(true) {
+    ignition_check(true),
+    app_storage_folder_(app_storage_folder) {
 }
 
 void PolicyManagerImpl::set_listener(PolicyListener* listener) {
@@ -904,19 +911,17 @@ bool PolicyManagerImpl::ResetPT(const std::string& file_name) {
 
 bool PolicyManagerImpl::CheckAppStorageFolder() const {
   LOG4CXX_AUTO_TRACE(logger_);
-  const std::string app_storage_folder =
-      profile::Profile::instance()->app_storage_folder();
-  LOG4CXX_DEBUG(logger_, "AppStorageFolder " << app_storage_folder);
-  if (!file_system::DirectoryExists(app_storage_folder)) {
+  LOG4CXX_DEBUG(logger_, "AppStorageFolder " << app_storage_folder_);
+  if (!file_system::DirectoryExists(app_storage_folder_)) {
     LOG4CXX_WARN(logger_,
-                 "Storage directory doesn't exist " << app_storage_folder);
+                 "Storage directory doesn't exist " << app_storage_folder_);
     return false;
   }
-  if (!(file_system::IsWritingAllowed(app_storage_folder) &&
-        file_system::IsReadingAllowed(app_storage_folder))) {
+  if (!(file_system::IsWritingAllowed(app_storage_folder_) &&
+        file_system::IsReadingAllowed(app_storage_folder_))) {
     LOG4CXX_WARN(
         logger_,
-        "Storage directory doesn't have read/write permissions " << app_storage_folder);
+        "Storage directory doesn't have read/write permissions " << app_storage_folder_);
     return false;
   }
   return true;

--- a/src/components/policy/src/policy/src/policy_table.cc
+++ b/src/components/policy/src/policy/src/policy_table.cc
@@ -40,10 +40,14 @@ namespace policy {
 
 CREATE_LOGGERPTR_GLOBAL(logger_, "PolicyTable")
 
-PolicyTable::PolicyTable()
+PolicyTable::PolicyTable(const std::string& app_storage_folder,
+                         uint16_t attempts_to_open_policy_db,
+                         uint16_t open_attempt_timeout_ms)
     : pt_data_(
-               new SQLPTRepresentation()
-               ) {
+        new SQLPTRepresentation(app_storage_folder,
+                                attempts_to_open_policy_db,
+                                open_attempt_timeout_ms)
+      ) {
 }
 
 PolicyTable::PolicyTable(utils::SharedPtr<PTRepresentation> pt_data)

--- a/src/components/policy/src/policy/src/sql_pt_representation.cc
+++ b/src/components/policy/src/policy/src/sql_pt_representation.cc
@@ -43,6 +43,7 @@
 #endif
 
 #include "utils/logger.h"
+#include "utils/threads/thread.h"
 #include "utils/file_system.h"
 #include "utils/gen_hash.h"
 #include "policy/sql_pt_representation.h"
@@ -339,19 +340,10 @@ InitResult SQLPTRepresentation::Init() {
     LOG4CXX_DEBUG(logger_, "Total attempts number is: "
                   << attempts_to_open_policy_db_);
     bool is_opened = false;
-#ifdef WIN_NATIVE
-    std::chrono::microseconds sleep_interval_mcsec(open_attempt_timeout_ms_ * 1000);
-#else
-    const useconds_t sleep_interval_mcsec = open_attempt_timeout_ms * 1000;
-#endif
     LOG4CXX_DEBUG(logger_, "Open attempt timeout(ms) is: "
                   << open_attempt_timeout_ms_);
     for (int i = 0; i < attempts_to_open_policy_db_; ++i) {
-#ifdef WIN_NATIVE
-      std::this_thread::sleep_for(std::chrono::microseconds(sleep_interval_mcsec));
-#else
-      usleep(sleep_interval_mcsec);
-#endif
+      threads::sleep(open_attempt_timeout_ms_);
       LOG4CXX_INFO(logger_, "Attempt: " << i+1);
       if (db_->Open()){
         LOG4CXX_INFO(logger_, "Database opened.");

--- a/src/components/policy/src/policy/src/sql_pt_representation.cc
+++ b/src/components/policy/src/policy/src/sql_pt_representation.cc
@@ -79,7 +79,7 @@ SQLPTRepresentation::SQLPTRepresentation(const std::string& app_storage_folder,
     open_attempt_timeout_ms_(open_attempt_timeout_ms) {
 #ifndef __QNX__
   if (!app_storage_folder_.empty()) {
-    db_->set_path(app_storage_folder_ + "/");
+    db_->set_path(app_storage_folder_ + file_system::GetPathDelimiter());
   }
 #endif  // __QNX__
 }

--- a/src/components/utils/include/utils/file_system.h
+++ b/src/components/utils/include/utils/file_system.h
@@ -275,6 +275,8 @@ bool IsRelativePath(const std::string& path);
   */
 void MakeAbsolutePath(std::string& path);
 
+std::string GetPathDelimiter();
+
 }  // namespace file_system
 
 #endif  // SRC_COMPONENTS_UTILS_INCLUDE_UTILS_FILE_SYSTEM_H_

--- a/src/components/utils/src/file_system_posix.cc
+++ b/src/components/utils/src/file_system_posix.cc
@@ -465,4 +465,8 @@ void file_system::MakeAbsolutePath(std::string& path) {
   path = file_system::CurrentWorkingDirectory() + "/" + path;
 }
 
+std::string file_system::GetPathDelimiter() {
+  return "/";
+}
+
 #endif // OS_POSIX

--- a/src/components/utils/src/file_system_win.cc
+++ b/src/components/utils/src/file_system_win.cc
@@ -91,17 +91,19 @@ size_t file_system::DirectorySize(const std::string& path) {
   do
   {
     if (FILE_ATTRIBUTE_DIRECTORY == ffd.dwFileAttributes) {
-	  size += DirectorySize(ffd.cFileName);
-	} else {
-	  uint64_t file_size = 0;
-	  file_size |= ffd.nFileSizeHigh;
+      if (std::string(ffd.cFileName).compare(".") != 0 &&
+            std::string(ffd.cFileName).compare("..") != 0) {
+        size += DirectorySize(ffd.cFileName);
+      }
+    } else {
+      uint64_t file_size = 0;
+      file_size |= ffd.nFileSizeHigh;
       file_size <<= 32;
       file_size |= ffd.nFileSizeLow;
 
-	  size += file_size;
-	}
-  }
-  while (FindNextFile(find, &ffd) != 0);
+      size += file_size;
+    }
+  } while (FindNextFile(find, &ffd) != 0);
 
   FindClose(find);
   return size;

--- a/src/components/utils/src/file_system_win.cc
+++ b/src/components/utils/src/file_system_win.cc
@@ -404,8 +404,12 @@ void file_system::MakeAbsolutePath(std::string& path) {
   TCHAR buffer[MAX_PATH];
   const DWORD size = GetFullPathName(path.c_str(), MAX_PATH, buffer, NULL);
   if (size != 0) {
-	  path.assign(buffer);
+    path.assign(buffer);
   }
+}
+
+std::string file_system::GetPathDelimiter() {
+  return "/";
 }
 
 #endif // WIN_NATIVE

--- a/src/components/utils/src/threads/posix_thread.cc
+++ b/src/components/utils/src/threads/posix_thread.cc
@@ -57,6 +57,10 @@ namespace threads {
 
 CREATE_LOGGERPTR_GLOBAL(logger_, "Utils")
 
+void sleep(uint32_t ms) {
+  usleep(ms * 1000);
+}
+
 size_t Thread::kMinStackSize = PTHREAD_STACK_MIN; /* Ubuntu : 16384 ; QNX : 256; */
 
 void Thread::cleanup(void* arg) {

--- a/src/components/utils/src/threads/win_thread.cc
+++ b/src/components/utils/src/threads/win_thread.cc
@@ -49,7 +49,12 @@ namespace threads {
 CREATE_LOGGERPTR_GLOBAL(logger_, "Utils")
 
 void sleep(uint32_t ms) {
+#ifdef SDL_CPP11
+  std::chrono::microseconds sleep_interval_mcsec(ms * 1000);
+  std::this_thread::sleep_for(std::chrono::microseconds(sleep_interval_mcsec));
+#else
   Sleep(ms);
+#endif
 }
 
 /* Parameter is not actual for Windows platform */

--- a/src/components/utils/src/threads/win_thread.cc
+++ b/src/components/utils/src/threads/win_thread.cc
@@ -48,6 +48,10 @@ namespace threads {
 
 CREATE_LOGGERPTR_GLOBAL(logger_, "Utils")
 
+void sleep(uint32_t ms) {
+  Sleep(ms);
+}
+
 /* Parameter is not actual for Windows platform */
 size_t Thread::kMinStackSize = 0; 
 


### PR DESCRIPTION
Comletely remove all calls by instance() from Policy.dll because of issue with singletons duplicating in dll in Windows. All parameters retrieved from Profile by instance() will be passed to policy library as constructor parameters.
