### PR TITLE
Add abbility to build 32bit openssl

### DIFF
--- a/cmake/Modules/FindWinOpenSSL.cmake
+++ b/cmake/Modules/FindWinOpenSSL.cmake
@@ -2,8 +2,13 @@
 #
 #  OPENSSL_INCLUDE_DIRECTORY - the OpenSSL include directory
 #  OPENSSL_LIB_DIRECTORY - the OpenSSL lib directory
+  if (${QT_PORT})
+    set(build_type x86)
+  else()
+    set(build_type x64)
+  endif()
   execute_process(
-      COMMAND ${CMAKE_SOURCE_DIR}/ms_tools/make_ssl_lib.cmd
+      COMMAND ${CMAKE_SOURCE_DIR}/ms_tools/make_ssl_lib.cmd ${build_type}
   )
 
 set(OPENSSL_INCLUDE_DIRECTORY $ENV{OPENSSL_DIR}/include)

--- a/ms_tools/make_ssl_lib.cmd
+++ b/ms_tools/make_ssl_lib.cmd
@@ -1,21 +1,52 @@
-@echo off 
-IF NOT EXIST "%BUILDDIR%\openssl" (
-pushd %BUILDDIR% > NUL
-@echo "Clone OpenSSSl"
+@echo off
+
+IF "%1"=="" GOTO :usage
+
+set build_type=%1
+
+IF NOT EXIST %BUILDDIR%\openssl (
+@echo "Clone OpenSSL"
 git.exe clone https://github.com/openssl/openssl.git
-pop > NUL
 )
-IF NOT EXIST "C:\Build-OpenSSL-VC-64" (
+
+IF %build_type%==x86 (
+set CONFIG_OPT=VC-WIN32 no-asm
+set ENV="%ProgramW6432%\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x86
+) ELSE IF %build_type%==x64 (
+set CONFIG_OPT=VC-WIN64A
+set ENV="%ProgramFiles(x86)%\Microsoft Visual Studio 12.0\VC\bin\x86_amd64\vcvarsx86_amd64.bat" x86_amd64
+) ELSE GOTO :usage
+
+IF NOT EXIST %BUILDDIR%\openssl_build_%build_type% (
 pushd %BUILDDIR%\openssl > NUL
-call "%ProgramFiles(x86)%\Microsoft Visual Studio 12.0\VC\bin\x86_amd64\vcvarsx86_amd64.bat" x86_amd64
-git.exe checkout origin/OpenSSL_1_0_2-stable
-@echo "Build OpenSSSl for VC x64"
-perl.exe Configure VC-WIN64A --prefix=C:\Build-OpenSSL-VC-64
+
+call git.exe clean -fxd
+call git.exe checkout origin/OpenSSL_1_0_2-stable
+
+@echo "Build OpenSSl for VC %build_type%"
+
+call %ENV%
+perl.exe Configure %CONFIG_OPT% --prefix=%BUILDDIR%\openssl_build_%build_type%
+
+IF %build_type%==x86 (
+call ms\do_ms
+nmake -f ms\ntdll.mak
+nmake -f ms\ntdll.mak install
+)ELSE if %build_type%==x64(
 call ms\do_win64a
 nmake -f ms\nt.mak
 nmake -f ms\nt.mak install
-setx OPENSSL_CONF C:\Build-OpenSSL-VC-64\bin\openssl.cfg /M
-setx OPENSSL_DIR C:\\Build-OpenSSL-VC-64 /M
-pop > NUL
+) ELSE goto :usage
+popd > NUL
 )
+
+IF NOT $OPENSSL_DIR==%BUILDDIR%\openssl_build_%build_type% (
+setx  OPENSSL_CONF %BUILDDIR%\openssl_build_%build_type%\bin\openssl.cfg
+setx  OPENSSL_DIR %BUILDDIR%\openssl_build_%build_type% 
+)
+
+goto :endl
+
+:usage
+@echo "please specify either x86 or x64 build type"
 :endl

--- a/src/appMain/CMakeLists.txt
+++ b/src/appMain/CMakeLists.txt
@@ -143,11 +143,8 @@ include_directories (
   ${default_media_inc}
   ${LOG4CXX_INCLUDE_DIRECTORY}
   ${OPENSSL_INCLUDE_DIRECTORY}
-<<<<<<< HEAD
   ${CMAKE_SOURCE_DIR}/src/3rd_party/dbus-1.7.8
   ${CMAKE_SOURCE_DIR}/src/3rd_party/dbus-1.7.8/dbus/
-=======
->>>>>>> a9c4c51... Fix Policy and TransportManager msvc build
 )
 
 set (SOURCES


### PR DESCRIPTION
In order to support Qt port SDL requires 32bit openssl.

In case user execute build for windows platform the batch file should build 64bit ssl
