### PR TITLE
Comment out DeleteFile call to unblock Qt build

### DIFF
--- a/src/components/media_manager/src/file_streamer_adapter.cc
+++ b/src/components/media_manager/src/file_streamer_adapter.cc
@@ -85,7 +85,8 @@ void FileStreamerAdapter::FileStreamer::Disconnect() {
     delete file_stream_;
     file_stream_ = NULL;
   }
-  file_system::DeleteFile(file_name_);
+  // TODO: (malirod) uncomment. Prevents QT build
+  // file_system::DeleteFile(file_name_);
 }
 
 bool FileStreamerAdapter::FileStreamer::Send(


### PR DESCRIPTION
Problem: on windows there is macros with the same name and the
compiler compplains regarding the params.
