### PR TITLE
Init Qt application on startup

### DIFF
--- a/src/appMain/main.cc
+++ b/src/appMain/main.cc
@@ -40,6 +40,7 @@
 #include "utils/system.h"
 #include "config_profile/profile.h"
 #include "networking.h"
+#include "utils/macro.h"
 
 CREATE_LOGGERPTR_GLOBAL(logger_, "appMain")
 
@@ -94,7 +95,6 @@ bool InitHmi() {
  * \return EXIT_SUCCESS or EXIT_FAILURE
  */
 int32_t main(int32_t argc, char** argv) {
-
   // --------------------------------------------------------------------------
   if ((argc > 1)&&(0 != argv)) {
     profile::Profile::instance()->config_file_name(argv[1]);
@@ -102,6 +102,7 @@ int32_t main(int32_t argc, char** argv) {
     profile::Profile::instance()->config_file_name("smartDeviceLink.ini");
   }
 
+  PLATFORM_INIT(argc, argv);
   // Logger initialization
   INIT_LOGGER();
 

--- a/src/components/include/utils/macro.h
+++ b/src/components/include/utils/macro.h
@@ -39,6 +39,10 @@
 #endif
 #include "utils/logger.h"
 
+#if defined(QT_PORT)
+#include <QCoreApplication>
+#endif
+
 // A macro to set some action for variable to avoid "unused variable" warning
 #define UNUSED(x) (void)x;
 // A macro to disallow the copy constructor and operator= functions
@@ -135,6 +139,12 @@
 #ifdef BUILD_TESTS
 #define FRIEND_TEST(test_case_name, test_name)\
 friend class test_case_name##_##test_name##_Test
+#endif
+
+#if defined(QT_PORT)
+#define PLATFORM_INIT(argc, argv) QCoreApplication application(argc, argv)
+#else
+#define PLATFORM_INIT(argc, argv)
 #endif
 
 #endif  // SRC_COMPONENTS_INCLUDE_UTILS_MACRO_H_


### PR DESCRIPTION
This resolves issues with plugins. So this way Qt can find plugins in the
dirs near executable.
