### PR TITLE
Fix crash during starting secure RPC service

### DIFF
--- a/src/components/security_manager/src/crypto_manager_impl.cc
+++ b/src/components/security_manager/src/crypto_manager_impl.cc
@@ -92,6 +92,9 @@ CryptoManagerImpl::CryptoManagerImpl()
     OpenSSL_add_all_algorithms();
     SSL_library_init();
   }
+  memset(&expiration_time_, 0, sizeof(expiration_time_));
+  // the minimum value for day of month is 1, otherwise exception will be thrown
+  expiration_time_.tm_mday = 1;
 }
 
 CryptoManagerImpl::~CryptoManagerImpl() {


### PR DESCRIPTION
The `struct tm` structure has not been initialized in `CryptoManger`
constructor. As the result the assertion has been appeared during
`asctime` function call.

Closes-Bug:[SDLWIN-280](https://adc.luxoft.com/jira/browse/SDLWIN-280)
