### PR TITLE
Make proper erasing from the map

### DIFF
--- a/src/3rd_party-static/MessageBroker/src/lib_messagebroker/CMessageBrokerRegistry.cpp
+++ b/src/3rd_party-static/MessageBroker/src/lib_messagebroker/CMessageBrokerRegistry.cpp
@@ -77,7 +77,7 @@ namespace NsMessageBroker
         std::map <std::string, int>::iterator it = mControllersList.begin();
         for (; it != mControllersList.end();) {
           if (it->second == fd) {
-            mControllersList.erase(it);
+            mControllersList.erase(it++);
           } else {
             ++it;
           }


### PR DESCRIPTION
Make proper erasing from the map
Closes-Bug: SDLWIN-274

<i>Note:</i> The bug is aactually fixed. But within this fix another deffect has appeared.
Deffect is about WSACleanup called twice and as the result we SDL loose connection with HMI
