### PR TITLE
Forbid thread terminating

### DIFF
--- a/src/components/include/utils/threads/thread.h
+++ b/src/components/include/utils/threads/thread.h
@@ -123,10 +123,6 @@ class Thread {
    */
   bool start(const ThreadOptions& options);
 
-#if defined(OS_WINDOWS)
-  void cleanup();
-#endif
-
   sync_primitives::Lock& delegate_lock() {
     return delegate_lock_;
   }
@@ -235,7 +231,6 @@ class Thread {
   Thread(const char* name, ThreadDelegate* delegate);
   virtual ~Thread();
   static void* threadFunc(void* arg);
-  static void cleanup(void* arg);
   DISALLOW_COPY_AND_ASSIGN(Thread);
 };
 

--- a/src/components/include/utils/threads/thread_delegate.h
+++ b/src/components/include/utils/threads/thread_delegate.h
@@ -59,7 +59,7 @@ class ThreadDelegate {
    * This function should be blocking and return only when threadMain() will be
    * finished in other case segmantation failes are possible
    */
-  virtual void exitThreadMain();
+  virtual void exitThreadMain() = 0;
 
   virtual ~ThreadDelegate();
 

--- a/src/components/transport_manager/include/transport_manager/usb/libusb/usb_handler.h
+++ b/src/components/transport_manager/include/transport_manager/usb/libusb/usb_handler.h
@@ -46,6 +46,7 @@
 #include "transport_manager/usb/libusb/platform_usb_device.h"
 #include "transport_manager/usb/usb_control_transfer.h"
 #include "utils/threads/thread.h"
+#include "utils/atomic_object.h"
 
 class Thread;
 
@@ -80,12 +81,13 @@ class UsbHandler {
    public:
     explicit UsbHandlerDelegate(UsbHandler* handler);
     void threadMain() OVERRIDE;
+    void exitThreadMain() OVERRIDE;
 
    private:
     UsbHandler* handler_;
   };
 
-  bool shutdown_requested_;
+  sync_primitives::atomic_bool shutdown_requested_;
   threads::Thread* thread_;
 
   friend class UsbDeviceListener;

--- a/src/components/utils/src/threads/posix_thread.cc
+++ b/src/components/utils/src/threads/posix_thread.cc
@@ -57,7 +57,7 @@ namespace {
 
 void cleanup(void* arg) {
   LOG4CXX_AUTO_TRACE(logger_);
-  Thread* thread = reinterpret_cast<Thread*>(arg);
+  Thread* thread = static_cast<Thread*>(arg);
   sync_primitives::AutoLock auto_lock(thread->state_lock_);
   thread->isThreadRunning_ = false;
   thread->state_cond_.Broadcast();

--- a/src/components/utils/src/threads/posix_thread.cc
+++ b/src/components/utils/src/threads/posix_thread.cc
@@ -53,6 +53,18 @@ const int EOK = 0;
 
 const size_t THREAD_NAME_SIZE = 15;
 
+namespace {
+
+void cleanup(void* arg) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  Thread* thread = reinterpret_cast<Thread*>(arg);
+  sync_primitives::AutoLock auto_lock(thread->state_lock_);
+  thread->isThreadRunning_ = false;
+  thread->state_cond_.Broadcast();
+}
+
+}  // namespace
+
 namespace threads {
 
 CREATE_LOGGERPTR_GLOBAL(logger_, "Utils")
@@ -63,14 +75,6 @@ void sleep(uint32_t ms) {
 
 size_t Thread::kMinStackSize =
     PTHREAD_STACK_MIN; /* Ubuntu : 16384 ; QNX : 256; */
-
-void Thread::cleanup(void* arg) {
-  LOG4CXX_AUTO_TRACE(logger_);
-  Thread* thread = reinterpret_cast<Thread*>(arg);
-  sync_primitives::AutoLock auto_lock(thread->state_lock_);
-  thread->isThreadRunning_ = false;
-  thread->state_cond_.Broadcast();
-}
 
 void* Thread::threadFunc(void* arg) {
   // 0 - state_lock unlocked

--- a/src/components/utils/src/threads/thread_delegate_posix.cc
+++ b/src/components/utils/src/threads/thread_delegate_posix.cc
@@ -46,16 +46,6 @@ ThreadDelegate::~ThreadDelegate() {
   }
 }
 
-void ThreadDelegate::exitThreadMain() {
-  if (thread_) {
-    if (thread_->thread_handle() == pthread_self()) {
-      pthread_exit(NULL);
-    } else {
-      pthread_cancel(thread_->thread_handle());
-    }
-  }
-}
-
 void ThreadDelegate::set_thread(Thread* thread) {
   DCHECK(thread);
   thread_ = thread;

--- a/src/components/utils/src/threads/thread_delegate_win.cc
+++ b/src/components/utils/src/threads/thread_delegate_win.cc
@@ -44,17 +44,6 @@ ThreadDelegate::~ThreadDelegate() {
   }
 }
 
-void ThreadDelegate::exitThreadMain() {
-  if (thread_) {
-    thread_->cleanup();
-    if (thread_->thread_handle() == GetCurrentThread()) {
-      ExitThread(NULL);
-    } else {
-      TerminateThread(thread_->thread_handle(), NULL);
-    }
-  }
-}
-
 void ThreadDelegate::set_thread(Thread* thread) {
   DCHECK(thread);
   thread_ = thread;

--- a/src/components/utils/src/threads/win_thread.cc
+++ b/src/components/utils/src/threads/win_thread.cc
@@ -60,14 +60,6 @@ void sleep(uint32_t ms) {
 /* Parameter is not actual for Windows platform */
 size_t Thread::kMinStackSize = 0;
 
-void Thread::cleanup(void* arg) {
-  LOG4CXX_AUTO_TRACE(logger_);
-  Thread* thread = reinterpret_cast<Thread*>(arg);
-  sync_primitives::AutoLock auto_lock(thread->state_lock_);
-  thread->isThreadRunning_ = false;
-  thread->state_cond_.Broadcast();
-}
-
 void* Thread::threadFunc(void* arg) {
   // 0 - state_lock unlocked
   //     stopped   = 0
@@ -135,11 +127,6 @@ Thread::Thread(const char* name, ThreadDelegate* delegate)
 
 bool Thread::start() {
   return start(thread_options_);
-}
-
-void Thread::cleanup() {
-  sync_primitives::AutoLock auto_lock(state_lock_);
-  cleanup(this);
 }
 
 PlatformThreadHandle Thread::CurrentId() {


### PR DESCRIPTION
Remove `exitThreadMain()` default implementation to avoid `TerminateThread()` call
