### PR TITLE
Provide fix for wrong `IsNull` statement

### DIFF
--- a/src/components/utils/src/sql_qt_wrapper/sql_query.cc
+++ b/src/components/utils/src/sql_qt_wrapper/sql_query.cc
@@ -145,7 +145,7 @@ std::string SQLQuery::query() const {
 }
 
 bool SQLQuery::IsNull(int pos) const {
-  return query_.boundValue(pos).isNull();
+  return query_.value(pos).isNull();
 }
 
 void SQLQuery::Bind(int pos, int value) {

--- a/src/components/utils/src/sql_qt_wrapper/sql_query.cc
+++ b/src/components/utils/src/sql_qt_wrapper/sql_query.cc
@@ -42,6 +42,7 @@
 #include <limits>
 
 #include "sql_qt_wrapper/sql_database.h"
+#include "utils/macro.h"
 
 namespace utils {
 namespace dbms {
@@ -129,10 +130,10 @@ int64_t SQLQuery::GetLongInt(int pos) {
   const qulonglong value = val.toULongLong();
   const qulonglong max_value =
       static_cast<qulonglong>(std::numeric_limits<int64_t>::max());
-  DCHECK(value <= max_value);
 
-  return std::min(std::numeric_limits<int64_t>::max(),
-                  static_cast<int64_t>(value));
+  DCHECK_OR_RETURN(value <= max_value, max_value);
+
+  return static_cast<int64_t>(value);
 }
 
 double SQLQuery::GetDouble(int pos) {

--- a/src/components/utils/src/sql_qt_wrapper/sql_query.cc
+++ b/src/components/utils/src/sql_qt_wrapper/sql_query.cc
@@ -39,6 +39,7 @@
 #include <QVariant>
 
 #include <cassert>
+#include <limits>
 
 #include "sql_qt_wrapper/sql_database.h"
 
@@ -125,7 +126,13 @@ uint32_t SQLQuery::GetUInteger(int pos) {
 int64_t SQLQuery::GetLongInt(int pos) {
   PreparePullValue(query_);
   const QVariant val = query_.value(pos);
-  return static_cast<int64_t>(val.toULongLong());
+  const qulonglong value = val.toULongLong();
+  const qulonglong max_value =
+      static_cast<qulonglong>(std::numeric_limits<int64_t>::max());
+  DCHECK(value <= max_value);
+
+  return std::min(std::numeric_limits<int64_t>::max(),
+                  static_cast<int64_t>(value));
 }
 
 double SQLQuery::GetDouble(int pos) {

--- a/src/components/utils/src/sql_qt_wrapper/sql_query.cc
+++ b/src/components/utils/src/sql_qt_wrapper/sql_query.cc
@@ -125,7 +125,7 @@ uint32_t SQLQuery::GetUInteger(int pos) {
 int64_t SQLQuery::GetLongInt(int pos) {
   PreparePullValue(query_);
   const QVariant val = query_.value(pos);
-  return val.toULongLong();
+  return static_cast<int64_t>(val.toULongLong());
 }
 
 double SQLQuery::GetDouble(int pos) {


### PR DESCRIPTION
Substitude query_.boundValue with query_.value since
boundValue has returned value which has been bounded
to the query whereas IsNull method has to check returned value
i.e. value which has been filed by QSQl engine for SELECT query

Fixes #88
