### PR TITLE
Call cleanup only on unnormal thread stop

### DIFF
--- a/src/components/include/utils/threads/thread.h
+++ b/src/components/include/utils/threads/thread.h
@@ -57,6 +57,7 @@ namespace threads {
 typedef pthread_t PlatformThreadHandle;
 #elif defined(OS_WINDOWS)
 typedef HANDLE PlatformThreadHandle;
+const int32_t kThreadCancelledExitCode = -1;
 #else
 #error "Thread is not defined for this platform"
 #endif

--- a/src/components/utils/src/threads/thread_delegate_win.cc
+++ b/src/components/utils/src/threads/thread_delegate_win.cc
@@ -45,9 +45,9 @@ ThreadDelegate::~ThreadDelegate() {
 void ThreadDelegate::exitThreadMain() {
   if (thread_) {
     if (thread_->thread_handle() == GetCurrentThread()) {
-      ExitThread(NULL);
+      ExitThread(-1);
     } else {
-      TerminateThread(thread_->thread_handle(), NULL);
+      TerminateThread(thread_->thread_handle(), -1);
     }
   }
 }

--- a/src/components/utils/src/threads/thread_delegate_win.cc
+++ b/src/components/utils/src/threads/thread_delegate_win.cc
@@ -45,9 +45,9 @@ ThreadDelegate::~ThreadDelegate() {
 void ThreadDelegate::exitThreadMain() {
   if (thread_) {
     if (thread_->thread_handle() == GetCurrentThread()) {
-      ExitThread(-1);
+      ExitThread(kThreadCancelledExitCode);
     } else {
-      TerminateThread(thread_->thread_handle(), -1);
+      TerminateThread(thread_->thread_handle(), kThreadCancelledExitCode);
     }
   }
 }

--- a/src/components/utils/src/threads/win_thread.cc
+++ b/src/components/utils/src/threads/win_thread.cc
@@ -186,8 +186,13 @@ void Thread::stop() {
   LOG4CXX_AUTO_TRACE(logger_);
   sync_primitives::AutoLock auto_lock(state_lock_);
 
+  // We should check thread exit code for kThreadCancelledExitCode
+  // because we need to perform cleanup in case thread has been terminated.
+  // If thread is still running - usual sequence with exitThreadMain will be
+  // used
   DWORD exit_code;
-  if (0 != GetExitCodeThread(handle_, &exit_code) && -1 == exit_code) {
+  if (0 != GetExitCodeThread(handle_, &exit_code) &&
+      kThreadCancelledExitCode == exit_code) {
     cleanup(static_cast<void*>(this));
   }
 

--- a/src/components/utils/src/threads/win_thread.cc
+++ b/src/components/utils/src/threads/win_thread.cc
@@ -61,7 +61,6 @@ size_t Thread::kMinStackSize = 0;
 void Thread::cleanup(void* arg) {
   LOG4CXX_AUTO_TRACE(logger_);
   Thread* thread = static_cast<Thread*>(arg);
-  sync_primitives::AutoLock auto_lock(thread->state_lock_);
   thread->isThreadRunning_ = false;
   thread->state_cond_.Broadcast();
 }
@@ -185,19 +184,21 @@ bool Thread::start(const ThreadOptions& options) {
 
 void Thread::stop() {
   LOG4CXX_AUTO_TRACE(logger_);
-  {
-    sync_primitives::AutoLock auto_lock(state_lock_);
+  sync_primitives::AutoLock auto_lock(state_lock_);
 
-    stopped_ = true;
-    LOG4CXX_DEBUG(logger_,
-                  "Stopping thread #" << handle_ << " \"" << name_ << " \"");
-
-    if (delegate_ && isThreadRunning_) {
-      delegate_->exitThreadMain();
-    }
+  DWORD exit_code;
+  if (0 != GetExitCodeThread(handle_, &exit_code) && -1 == exit_code) {
+    cleanup(static_cast<void*>(this));
   }
 
-  cleanup(static_cast<void*>(this));
+  stopped_ = true;
+  LOG4CXX_DEBUG(logger_,
+                "Stopping thread #" << handle_ << " \"" << name_ << " \"");
+
+  if (delegate_ && isThreadRunning_) {
+    delegate_->exitThreadMain();
+  }
+
   LOG4CXX_DEBUG(logger_,
                 "Stopped thread #" << handle_ << " \"" << name_ << " \"");
 }


### PR DESCRIPTION
We should call `cleanup` method only in case thread had been terminated to keep `Thread` internal fields consistent. In `POSIX` version this call is performed by `pthread` library on each `pthread_cancel` call. Windows doesn't provide such functionality so we have to set `-1` as thread exit value on `ThreadTerminate` or `ExitThread` call and than check this value to decide call `cleanup` or not (we call `cleanup` if thread exit value equal to -1)
