### PR TITLE
Provide long file paths support

### DIFF
--- a/src/appMain/smartDeviceLink.ini
+++ b/src/appMain/smartDeviceLink.ini
@@ -77,8 +77,8 @@ HeartBeatTimeout = 7000
 ; Only the stated values are allowed by SDL in terms of DiagnosticMessage RPC, others are rejected
 SupportedDiagModes = 0x01, 0x02, 0x03, 0x05, 0x06, 0x07, 0x09, 0x0A, 0x18, 0x19, 0x22, 0x3E
 ; The path to the system file directory for inter-operation between SDL and System (e.g. IVSU files and others).
-; If parameter is empty, SDL uses /tmp/fs/mp/images/ivsu_cache by default
-SystemFilesPath = /tmp/fs/mp/images/ivsu_cache
+; If parameter is empty, SDL uses ivsu_cache by default
+SystemFilesPath = ivsu_cache
 ; To restore the last transport state (name, applications or channels) on SDL on a new device connection and on disconnect
 UseLastState = true
 ; Port to obtain the performance information about messages processing

--- a/src/components/application_manager/include/application_manager/application_manager_impl.h
+++ b/src/components/application_manager/include/application_manager/application_manager_impl.h
@@ -879,7 +879,7 @@ class ApplicationManagerImpl
    * @param name of the app folder(make + mobile app id)
    * @return free app space.
    */
-  uint32_t GetAvailableSpaceForApp(const std::string& folder_name);
+  uint64_t GetAvailableSpaceForApp(const std::string& folder_name);
 
   /*
    * @brief returns true if HMI is cooperating

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -2993,7 +2993,7 @@ mobile_apis::Result::eType ApplicationManagerImpl::SaveBinary(
 
   const std::string full_file_path =
       file_system::ConcatPath(file_path, file_name);
-  int64_t file_size = file_system::FileSize(full_file_path);
+  uint64_t file_size = file_system::FileSize(full_file_path);
   std::ofstream* file_stream;
   if (offset != 0) {
     if (file_size != offset) {
@@ -3026,20 +3026,20 @@ mobile_apis::Result::eType ApplicationManagerImpl::SaveBinary(
   return mobile_apis::Result::SUCCESS;
 }
 
-uint32_t ApplicationManagerImpl::GetAvailableSpaceForApp(
+uint64_t ApplicationManagerImpl::GetAvailableSpaceForApp(
     const std::string& folder_name) {
   const uint32_t app_quota = profile::Profile::instance()->app_dir_quota();
   std::string app_storage_path = file_system::ConcatPath(
       profile::Profile::instance()->app_storage_folder(), folder_name);
 
   if (file_system::DirectoryExists(app_storage_path)) {
-    size_t size_of_directory = file_system::DirectorySize(app_storage_path);
+    uint64_t size_of_directory = file_system::DirectorySize(app_storage_path);
     if (app_quota < size_of_directory) {
       return 0;
     }
 
-    uint32_t current_app_quota = app_quota - size_of_directory;
-    uint32_t available_disk_space =
+    uint64_t current_app_quota = app_quota - size_of_directory;
+    uint64_t available_disk_space =
         file_system::GetAvailableDiskSpace(app_storage_path);
 
     if (current_app_quota > available_disk_space) {

--- a/src/components/application_manager/src/commands/mobile/list_files_request.cc
+++ b/src/components/application_manager/src/commands/mobile/list_files_request.cc
@@ -83,9 +83,9 @@ void ListFilesRequest::Run() {
        ++it) {
     // In AppFile to application stored full path to file. In message required
     // to write only name file.
-    // Plus one required for move to next letter after '/'.
+    // Plus one required for move to next letter after delimiter.
     (*message_)[strings::msg_params][strings::filenames][i++] =
-        it->first.substr(it->first.find_last_of('/') + 1);
+        file_system::RetrieveFileNameFromPath(it->first);
   }
   (*message_)[strings::params][strings::message_type] =
       application_manager::MessageType::kResponse;

--- a/src/components/application_manager/src/commands/mobile/put_file_request.cc
+++ b/src/components/application_manager/src/commands/mobile/put_file_request.cc
@@ -151,7 +151,7 @@ void PutFileRequest::Run() {
         profile::Profile::instance()->app_storage_folder(),
         application->folder_name());
 
-    uint32_t space_available =
+    uint64_t space_available =
         ApplicationManagerImpl::instance()->GetAvailableSpaceForApp(
             application->folder_name());
 

--- a/src/components/application_manager/src/commands/mobile/set_app_icon_request.cc
+++ b/src/components/application_manager/src/commands/mobile/set_app_icon_request.cc
@@ -141,8 +141,7 @@ void SetAppIconRequest::CopyToIconStorage(
     return;
   }
 
-  const uint64_t storage_size =
-      static_cast<uint64_t>(file_system::DirectorySize(icon_storage));
+  const uint64_t storage_size = file_system::DirectorySize(icon_storage);
   if (storage_max_size < (file_size + storage_size)) {
     const uint32_t icons_amount =
         profile::Profile::instance()->app_icons_amount_to_remove();
@@ -224,8 +223,7 @@ bool SetAppIconRequest::IsEnoughSpaceForIcon(const uint64_t icon_size) const {
       profile::Profile::instance()->app_icons_folder();
   const uint64_t storage_max_size = static_cast<uint64_t>(
       profile::Profile::instance()->app_icons_folder_max_size());
-  const uint64_t storage_size =
-      static_cast<uint64_t>(file_system::DirectorySize(icon_storage));
+  const uint64_t storage_size = file_system::DirectorySize(icon_storage);
   return storage_max_size >= (icon_size + storage_size);
 }
 

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -122,8 +122,7 @@ const char* const kPolicyLibraryName = "Policy";
       LOG4CXX_DEBUG(logger_, "The shared library of policy is not loaded"); \
       return return_value;                                                  \
     }                                                                       \
-  \
-}
+  }
 
 #define POLICY_LIB_CHECK_VOID()                                             \
   {                                                                         \
@@ -132,8 +131,7 @@ const char* const kPolicyLibraryName = "Policy";
       LOG4CXX_DEBUG(logger_, "The shared library of policy is not loaded"); \
       return;                                                               \
     }                                                                       \
-  \
-}
+  }
 
 CREATE_LOGGERPTR_GLOBAL(logger_, "PolicyHandler")
 
@@ -1033,7 +1031,8 @@ bool PolicyHandler::SaveSnapshot(const BinaryMessage& pt_string,
       Profile::instance()->policies_snapshot_file_name();
   const std::string& system_files_path =
       Profile::instance()->system_files_path();
-  snap_path = system_files_path + '/' + policy_snapshot_file_name;
+  snap_path = system_files_path + file_system::GetPathDelimiter() +
+              policy_snapshot_file_name;
 
   bool result = false;
   if (file_system::CreateDirectoryRecursively(system_files_path)) {

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -1031,8 +1031,8 @@ bool PolicyHandler::SaveSnapshot(const BinaryMessage& pt_string,
       Profile::instance()->policies_snapshot_file_name();
   const std::string& system_files_path =
       Profile::instance()->system_files_path();
-  snap_path = system_files_path + file_system::GetPathDelimiter() +
-              policy_snapshot_file_name;
+  snap_path =
+      file_system::ConcatPath(system_files_path, policy_snapshot_file_name);
 
   bool result = false;
   if (file_system::CreateDirectoryRecursively(system_files_path)) {

--- a/src/components/application_manager/src/request_controller.cc
+++ b/src/components/application_manager/src/request_controller.cc
@@ -509,21 +509,21 @@ void RequestController::UpdateTimer() {
 
       timer_.updateTimeOut(msecs);
     } else {
-      LOG4CXX_WARN(logger_,
-                   "Request app_id: "
-                       << front->app_id()
-                       << " correlation_id: "
-                       << front->requestId()
-                       << " is expired. "
-                       << "End time (ms): "
-                       << date_time::DateTime::getmSecs(end_time)
-                       << " Current time (ms): "
-                       << date_time::DateTime::getmSecs(current_time)
-                       << " Diff (current - end) (ms): "
-                       << date_time::DateTime::getmSecs(current_time - end_time)
-                       << " Request timeout (sec): "
-                       << front->timeout_msec() /
-                              date_time::DateTime::MILLISECONDS_IN_SECOND);
+      LOG4CXX_WARN(
+          logger_,
+          "Request app_id: "
+              << front->app_id()
+              << " correlation_id: "
+              << front->requestId()
+              << " is expired. "
+              << "End time (ms): "
+              << date_time::DateTime::getmSecs(end_time)
+              << " Current time (ms): "
+              << date_time::DateTime::getmSecs(current_time)
+              << " Diff (current - end) (ms): "
+              << date_time::DateTime::getmSecs(current_time - end_time)
+              << " Request timeout (sec): "
+              << front->timeout_msec() / date_time::kMillisecondsInSecond);
       timer_.updateTimeOut(0);
     }
   } else {

--- a/src/components/config_profile/src/profile.cc
+++ b/src/components/config_profile/src/profile.cc
@@ -865,10 +865,8 @@ void Profile::UpdateValues() {
                   kMainSection,
                   kAppConfigFolderKey);
 
-  if (file_system::IsRelativePath(app_config_folder_)) {
-    app_config_folder_ = file_system::ConcatPath(
-        file_system::CurrentWorkingDirectory(), app_config_folder_);
-  }
+  app_config_folder_ =
+      file_system::ConcatCurrentWorkingPath(app_config_folder_);
 
   LOG_UPDATED_VALUE(app_config_folder_, kAppConfigFolderKey, kMainSection);
 
@@ -878,10 +876,8 @@ void Profile::UpdateValues() {
                   kMainSection,
                   kAppStorageFolderKey);
 
-  if (file_system::IsRelativePath(app_storage_folder_)) {
-    app_storage_folder_ = file_system::ConcatPath(
-        file_system::CurrentWorkingDirectory(), app_storage_folder_);
-  }
+  app_storage_folder_ =
+      file_system::ConcatCurrentWorkingPath(app_storage_folder_);
 
   LOG_UPDATED_VALUE(app_storage_folder_, kAppStorageFolderKey, kMainSection);
 
@@ -891,10 +887,8 @@ void Profile::UpdateValues() {
                   kMainSection,
                   kAppResourseFolderKey);
 
-  if (file_system::IsRelativePath(app_resourse_folder_)) {
-    app_resourse_folder_ = file_system::ConcatPath(
-        file_system::CurrentWorkingDirectory(), app_resourse_folder_);
-  }
+  app_resourse_folder_ =
+      file_system::ConcatCurrentWorkingPath(app_resourse_folder_);
 
   LOG_UPDATED_VALUE(app_resourse_folder_, kAppResourseFolderKey, kMainSection);
 
@@ -915,10 +909,7 @@ void Profile::UpdateValues() {
                   kSDL4Section,
                   kAppIconsFolderKey);
 
-  if (file_system::IsRelativePath(app_icons_folder_)) {
-    app_icons_folder_ = file_system::ConcatPath(
-        file_system::CurrentWorkingDirectory(), app_icons_folder_);
-  }
+  app_icons_folder_ = file_system::ConcatCurrentWorkingPath(app_icons_folder_);
 
   LOG_UPDATED_VALUE(app_icons_folder_, kAppIconsFolderKey, kSDL4Section);
 
@@ -1390,10 +1381,8 @@ void Profile::UpdateValues() {
                   kMainSection,
                   kSystemFilesPathKey);
 
-  if (file_system::IsRelativePath(system_files_path_)) {
-    system_files_path_ = file_system::ConcatPath(
-        file_system::CurrentWorkingDirectory(), system_files_path_);
-  }
+  system_files_path_ =
+      file_system::ConcatCurrentWorkingPath(system_files_path_);
 
   LOG_UPDATED_VALUE(system_files_path_, kSystemFilesPathKey, kMainSection);
 

--- a/src/components/config_profile/src/profile.cc
+++ b/src/components/config_profile/src/profile.cc
@@ -203,7 +203,7 @@ const char* kDefaultHmiCapabilitiesFileName = "hmi_capabilities.json";
 const char* kDefaultPreloadedPTFileName = "sdl_preloaded_pt.json";
 const char* kDefaultServerAddress = "127.0.0.1";
 const char* kDefaultAppInfoFileName = "app_info.dat";
-const char* kDefaultSystemFilesPath = "/tmp/fs/mp/images/ivsu_cache";
+const char* kDefaultSystemFilesPath = "ivsu_cache";
 const char* kDefaultTtsDelimiter = ",";
 const uint32_t kDefaultAudioDataStoppedTimeout = 1000;
 const uint32_t kDefaultVideoDataStoppedTimeout = 1000;
@@ -1472,7 +1472,8 @@ void Profile::UpdateValues() {
                   kPolicySection,
                   kPreloadedPTKey);
 
-  preloaded_pt_file_ = app_config_folder_ + '/' + preloaded_pt_file_;
+  preloaded_pt_file_ =
+      app_config_folder_ + file_system::GetPathDelimiter() + preloaded_pt_file_;
 
   LOG_UPDATED_VALUE(preloaded_pt_file_, kPreloadedPTKey, kPolicySection);
 

--- a/src/components/config_profile/src/profile.cc
+++ b/src/components/config_profile/src/profile.cc
@@ -1473,7 +1473,7 @@ void Profile::UpdateValues() {
                   kPreloadedPTKey);
 
   preloaded_pt_file_ =
-      app_config_folder_ + file_system::GetPathDelimiter() + preloaded_pt_file_;
+      file_system::ConcatPath(app_config_folder_, preloaded_pt_file_);
 
   LOG_UPDATED_VALUE(preloaded_pt_file_, kPreloadedPTKey, kPolicySection);
 

--- a/src/components/config_profile/src/profile.cc
+++ b/src/components/config_profile/src/profile.cc
@@ -866,7 +866,8 @@ void Profile::UpdateValues() {
                   kAppConfigFolderKey);
 
   if (file_system::IsRelativePath(app_config_folder_)) {
-    file_system::MakeAbsolutePath(app_config_folder_);
+    app_config_folder_ = file_system::ConcatPath(
+        file_system::CurrentWorkingDirectory(), app_config_folder_);
   }
 
   LOG_UPDATED_VALUE(app_config_folder_, kAppConfigFolderKey, kMainSection);
@@ -878,7 +879,8 @@ void Profile::UpdateValues() {
                   kAppStorageFolderKey);
 
   if (file_system::IsRelativePath(app_storage_folder_)) {
-    file_system::MakeAbsolutePath(app_storage_folder_);
+    app_storage_folder_ = file_system::ConcatPath(
+        file_system::CurrentWorkingDirectory(), app_storage_folder_);
   }
 
   LOG_UPDATED_VALUE(app_storage_folder_, kAppStorageFolderKey, kMainSection);
@@ -890,7 +892,8 @@ void Profile::UpdateValues() {
                   kAppResourseFolderKey);
 
   if (file_system::IsRelativePath(app_resourse_folder_)) {
-    file_system::MakeAbsolutePath(app_resourse_folder_);
+    app_resourse_folder_ = file_system::ConcatPath(
+        file_system::CurrentWorkingDirectory(), app_resourse_folder_);
   }
 
   LOG_UPDATED_VALUE(app_resourse_folder_, kAppResourseFolderKey, kMainSection);
@@ -913,7 +916,8 @@ void Profile::UpdateValues() {
                   kAppIconsFolderKey);
 
   if (file_system::IsRelativePath(app_icons_folder_)) {
-    file_system::MakeAbsolutePath(app_icons_folder_);
+    app_icons_folder_ = file_system::ConcatPath(
+        file_system::CurrentWorkingDirectory(), app_icons_folder_);
   }
 
   LOG_UPDATED_VALUE(app_icons_folder_, kAppIconsFolderKey, kSDL4Section);
@@ -1385,8 +1389,10 @@ void Profile::UpdateValues() {
                   kDefaultSystemFilesPath,
                   kMainSection,
                   kSystemFilesPathKey);
+
   if (file_system::IsRelativePath(system_files_path_)) {
-    file_system::MakeAbsolutePath(system_files_path_);
+    system_files_path_ = file_system::ConcatPath(
+        file_system::CurrentWorkingDirectory(), system_files_path_);
   }
 
   LOG_UPDATED_VALUE(system_files_path_, kSystemFilesPathKey, kMainSection);

--- a/src/components/include/utils/date_time.h
+++ b/src/components/include/utils/date_time.h
@@ -46,12 +46,14 @@ namespace date_time {
 
 enum TimeCompare { LESS, EQUAL, GREATER };
 
+const uint64_t kDeltaEpochInMicrosecs = 11644473600000000u;
+const uint32_t kMillisecondsInSecond = 1000u;
+const uint32_t kMicrosecondsInMillisecond = 1000u;
+const uint32_t kMicrosecondsInSecond =
+    kMillisecondsInSecond * kMicrosecondsInMillisecond;
+
 class DateTime {
  public:
-  static const int32_t MILLISECONDS_IN_SECOND = 1000;
-  static const int32_t MICROSECONDS_IN_MILLISECONDS = 1000;
-  static const int32_t MICROSECONDS_IN_SECOND = 1000 * 1000;
-
   static TimevalStruct getCurrentTime();
 
   // return SECONDS count

--- a/src/components/include/utils/messagemeter.h
+++ b/src/components/include/utils/messagemeter.h
@@ -144,13 +144,10 @@ void MessageMeter<Id>::ClearIdentifiers() {
 template <class Id>
 void MessageMeter<Id>::set_time_range(const size_t time_range_msecs) {
   // TODO(EZamakhov): move to date_time::DateTime
-  const size_t secs =
-      time_range_msecs / date_time::DateTime::MILLISECONDS_IN_SECOND;
+  const size_t secs = time_range_msecs / date_time::kMillisecondsInSecond;
   time_range_.tv_sec = secs;
-  const size_t mSecs =
-      time_range_msecs % date_time::DateTime::MILLISECONDS_IN_SECOND;
-  time_range_.tv_usec =
-      mSecs * date_time::DateTime::MICROSECONDS_IN_MILLISECONDS;
+  const size_t mSecs = time_range_msecs % date_time::kMillisecondsInSecond;
+  time_range_.tv_usec = mSecs * date_time::kMicrosecondsInMillisecond;
 }
 template <class Id>
 void MessageMeter<Id>::set_time_range(const TimevalStruct& time_range) {

--- a/src/components/policy/src/policy/usage_statistics/src/counter.cc
+++ b/src/components/policy/src/policy/usage_statistics/src/counter.cc
@@ -108,7 +108,7 @@ AppStopwatch::~AppStopwatch() {
 
 void AppStopwatch::Start(AppStopwatchId stopwatch_type) {
   stopwatch_type_ = stopwatch_type;
-  timer_->start(time_out_ * date_time::DateTime::MILLISECONDS_IN_SECOND);
+  timer_->start(time_out_ * date_time::kMillisecondsInSecond);
 }
 
 void AppStopwatch::Switch(AppStopwatchId stopwatch_type) {

--- a/src/components/utils/include/utils/file_system.h
+++ b/src/components/utils/include/utils/file_system.h
@@ -224,7 +224,7 @@ bool CreateFile(const std::string& utf8_path);
 /**
  * @brief Get modification time of file
  * @param utf8_path Path to file
- * @return Modification time in nanoseconds
+ * @return Modification time in seconds
  */
 uint64_t GetFileModificationTime(const std::string& utf8_path);
 

--- a/src/components/utils/include/utils/file_system.h
+++ b/src/components/utils/include/utils/file_system.h
@@ -40,25 +40,27 @@
 
 namespace file_system {
 
+typedef uint64_t FileSizeType;
+
 /**
  * @brief Get available disc space.
  * @param utf8_path path to directory
  * @return free disc space.
  */
-uint64_t GetAvailableDiskSpace(const std::string& utf8_path);
+FileSizeType GetAvailableDiskSpace(const std::string& utf8_path);
 
 /*
  * @brief Get size of current directory
  * @param utf8_path path to directory
  */
-uint64_t DirectorySize(const std::string& utf8_path);
+FileSizeType DirectorySize(const std::string& utf8_path);
 
 /*
  * @brief Get size of current file
  * @param utf8_path path to file
  * @return size of file, return 0 if file not exist
  */
-uint64_t FileSize(const std::string& utf8_path);
+FileSizeType FileSize(const std::string& utf8_path);
 
 /**
  * @brief Creates directory

--- a/src/components/utils/include/utils/file_system.h
+++ b/src/components/utils/include/utils/file_system.h
@@ -128,8 +128,7 @@ void Close(std::ofstream* file_stream);
 
 /**
   * @brief Returns current working directory path
-  * If filename begins with "/", return unchanged filename
-  * @return returns full file path.
+  * @return Current working directory path
   */
 std::string CurrentWorkingDirectory();
 

--- a/src/components/utils/include/utils/file_system.h
+++ b/src/components/utils/include/utils/file_system.h
@@ -279,6 +279,13 @@ std::string ConcatPath(const std::string& utf8_path1,
                        const std::string& utf8_path3);
 
 /**
+  * @brief Concatenates path to current working directory path
+  * @param utf8_path Path to be concatenated
+  * @return Concatenated path string
+  */
+std::string ConcatCurrentWorkingPath(const std::string& utf8_path);
+
+/**
   * @brief Retrieves file name from path by
   * removing all before last path delimiter
   * @param utf8_path Path to process

--- a/src/components/utils/include/utils/file_system.h
+++ b/src/components/utils/include/utils/file_system.h
@@ -51,14 +51,14 @@ uint64_t GetAvailableDiskSpace(const std::string& utf8_path);
  * @brief Get size of current directory
  * @param utf8_path path to directory
  */
-size_t DirectorySize(const std::string& utf8_path);
+uint64_t DirectorySize(const std::string& utf8_path);
 
 /*
  * @brief Get size of current file
  * @param utf8_path path to file
  * @return size of file, return 0 if file not exist
  */
-int64_t FileSize(const std::string& utf8_path);
+uint64_t FileSize(const std::string& utf8_path);
 
 /**
  * @brief Creates directory

--- a/src/components/utils/include/utils/file_system.h
+++ b/src/components/utils/include/utils/file_system.h
@@ -75,13 +75,6 @@ std::string CreateDirectory(const std::string& utf8_path);
 bool CreateDirectoryRecursively(const std::string& utf8_path);
 
 /**
-  * @brief Checks the file to see whether the file is a directory
-  * @param utf8_path path to file
-  * @return returns true if file is directory.
-  */
-bool IsDirectory(const std::string& utf8_path);
-
-/**
   * @brief Is directory exist
   * @param utf8_path path to directory
   * @return returns true if directory is exists.

--- a/src/components/utils/include/utils/file_system.h
+++ b/src/components/utils/include/utils/file_system.h
@@ -125,7 +125,7 @@ std::ofstream* Open(const std::string& utf8_path,
   */
 bool Write(std::ofstream* const file_stream,
            const uint8_t* data,
-           uint32_t data_size);
+           size_t data_size);
 
 /**
   * @brief Closes file stream
@@ -194,11 +194,11 @@ std::vector<std::string> ListFiles(const std::string& utf8_path);
 /**
  * @brief Creates or overwrites file with given binary contents
  * @param utf8_path path to the file
- * @param contents data to be written into the file
+ * @param data data to be written into the file
  * @returns true if file write succeeded
  */
 bool WriteBinaryFile(const std::string& utf8_path,
-                     const std::vector<uint8_t>& contents);
+                     const std::vector<uint8_t>& data);
 
 /**
   * @brief Reads from file

--- a/src/components/utils/include/utils/file_system.h
+++ b/src/components/utils/include/utils/file_system.h
@@ -118,7 +118,7 @@ std::ofstream* Open(const std::string& utf8_path,
   */
 bool Write(std::ofstream* const file_stream,
            const uint8_t* data,
-           size_t data_size);
+           std::size_t data_size);
 
 /**
   * @brief Closes file stream

--- a/src/components/utils/include/utils/file_system.h
+++ b/src/components/utils/include/utils/file_system.h
@@ -268,12 +268,6 @@ void RemoveDirectoryContent(const std::string& utf8_path);
 bool IsRelativePath(const std::string& utf8_path);
 
 /**
-  * @brief Converts path from relative to absolute
-  * @param utf8_path Path to convert
-  */
-void MakeAbsolutePath(std::string& utf8_path);
-
-/**
   * @brief Returns platform specific path delimiter
   * @return Delimiter string
   */

--- a/src/components/utils/include/utils/winhdr.h
+++ b/src/components/utils/include/utils/winhdr.h
@@ -58,8 +58,16 @@
 #undef DeleteFile
 #endif
 
+#ifdef CreateDirectory
+#undef CreateDirectory
+#endif
+
 #ifdef RemoveDirectory
 #undef RemoveDirectory
+#endif
+
+#ifdef CopyFile
+#undef CopyFile
 #endif
 
 #ifdef MoveFile

--- a/src/components/utils/src/date_time_posix.cc
+++ b/src/components/utils/src/date_time_posix.cc
@@ -52,14 +52,14 @@ int64_t date_time::DateTime::getSecs(const TimevalStruct& time) {
 
 int64_t DateTime::getmSecs(const TimevalStruct& time) {
   const TimevalStruct times = ConvertionUsecs(time);
-  return static_cast<int64_t>(times.tv_sec) * MILLISECONDS_IN_SECOND +
-         times.tv_usec / MICROSECONDS_IN_MILLISECONDS;
+  return static_cast<int64_t>(times.tv_sec) * kMillisecondsInSecond +
+         times.tv_usec / kMicrosecondsInMillisecond;
 }
 
 int64_t DateTime::getuSecs(const TimevalStruct& time) {
   const TimevalStruct times = ConvertionUsecs(time);
-  return static_cast<int64_t>(times.tv_sec) * MILLISECONDS_IN_SECOND *
-             MICROSECONDS_IN_MILLISECONDS +
+  return static_cast<int64_t>(times.tv_sec) * kMillisecondsInSecond *
+             kMicrosecondsInMillisecond +
          times.tv_usec;
 }
 
@@ -81,9 +81,9 @@ int64_t DateTime::calculateTimeDiff(const TimevalStruct& time1,
 }
 
 void DateTime::AddMilliseconds(TimevalStruct& time, uint32_t milliseconds) {
-  const uint32_t sec = milliseconds / MILLISECONDS_IN_SECOND;
+  const uint32_t sec = milliseconds / kMillisecondsInSecond;
   const uint32_t usec =
-      (milliseconds % MILLISECONDS_IN_SECOND) * MICROSECONDS_IN_MILLISECONDS;
+      (milliseconds % kMillisecondsInSecond) * kMicrosecondsInMillisecond;
   time.tv_sec += sec;
   time.tv_usec += usec;
   time = ConvertionUsecs(time);
@@ -126,11 +126,11 @@ TimeCompare date_time::DateTime::compareTime(const TimevalStruct& time1,
 }
 
 TimevalStruct date_time::DateTime::ConvertionUsecs(const TimevalStruct& time) {
-  if (time.tv_usec >= MICROSECONDS_IN_SECOND) {
+  if (time.tv_usec >= kMicrosecondsInSecond) {
     TimevalStruct time1;
     time1.tv_sec = static_cast<int64_t>(time.tv_sec) +
-                   (time.tv_usec / MICROSECONDS_IN_SECOND);
-    time1.tv_usec = static_cast<int64_t>(time.tv_usec) % MICROSECONDS_IN_SECOND;
+                   (time.tv_usec / kMicrosecondsInSecond);
+    time1.tv_usec = static_cast<int64_t>(time.tv_usec) % kMicrosecondsInSecond;
     return time1;
   }
   return time;

--- a/src/components/utils/src/date_time_qt.cc
+++ b/src/components/utils/src/date_time_qt.cc
@@ -48,8 +48,8 @@ TimevalStruct DateTime::getCurrentTime() {
 
   // Finally change microseconds to seconds and place in the seconds value.
   // The modulus picks up the microseconds.
-  tv.tv_sec = (long)(tmpres / MICROSECONDS_IN_SECOND);
-  tv.tv_usec = (long)(tmpres % MICROSECONDS_IN_SECOND);
+  tv.tv_sec = (long)(tmpres / kMicrosecondsInSecond);
+  tv.tv_usec = (long)(tmpres % kMicrosecondsInSecond);
 
   return tv;
 }
@@ -61,14 +61,14 @@ int64_t date_time::DateTime::getSecs(const TimevalStruct& time) {
 
 int64_t DateTime::getmSecs(const TimevalStruct& time) {
   const TimevalStruct times = ConvertionUsecs(time);
-  return static_cast<int64_t>(times.tv_sec) * MILLISECONDS_IN_SECOND +
-         times.tv_usec / MICROSECONDS_IN_MILLISECONDS;
+  return static_cast<int64_t>(times.tv_sec) * kMillisecondsInSecond +
+         times.tv_usec / kMicrosecondsInMillisecond;
 }
 
 int64_t DateTime::getuSecs(const TimevalStruct& time) {
   const TimevalStruct times = ConvertionUsecs(time);
-  return static_cast<int64_t>(times.tv_sec) * MILLISECONDS_IN_SECOND *
-             MICROSECONDS_IN_MILLISECONDS +
+  return static_cast<int64_t>(times.tv_sec) * kMillisecondsInSecond *
+             kMicrosecondsInMillisecond +
          times.tv_usec;
 }
 
@@ -90,9 +90,9 @@ int64_t DateTime::calculateTimeDiff(const TimevalStruct& time1,
 }
 
 void DateTime::AddMilliseconds(TimevalStruct& time, uint32_t milliseconds) {
-  const uint32_t sec = milliseconds / MILLISECONDS_IN_SECOND;
+  const uint32_t sec = milliseconds / kMillisecondsInSecond;
   const uint32_t usec =
-      (milliseconds % MILLISECONDS_IN_SECOND) * MICROSECONDS_IN_MILLISECONDS;
+      (milliseconds % kMillisecondsInSecond) * kMicrosecondsInMillisecond;
   time.tv_sec += sec;
   time.tv_usec += usec;
   time = ConvertionUsecs(time);
@@ -141,11 +141,11 @@ TimeCompare date_time::DateTime::compareTime(const TimevalStruct& time1,
 }
 
 TimevalStruct date_time::DateTime::ConvertionUsecs(const TimevalStruct& time) {
-  if (time.tv_usec >= MICROSECONDS_IN_SECOND) {
+  if (time.tv_usec >= kMicrosecondsInSecond) {
     TimevalStruct time1;
     time1.tv_sec = static_cast<int64_t>(time.tv_sec) +
-                   (time.tv_usec / MICROSECONDS_IN_SECOND);
-    time1.tv_usec = static_cast<int64_t>(time.tv_usec) % MICROSECONDS_IN_SECOND;
+                   (time.tv_usec / kMicrosecondsInSecond);
+    time1.tv_usec = static_cast<int64_t>(time.tv_usec) % kMicrosecondsInSecond;
     return time1;
   }
   return time;

--- a/src/components/utils/src/date_time_win.cc
+++ b/src/components/utils/src/date_time_win.cc
@@ -37,10 +37,6 @@
 #include "utils/winhdr.h"
 #include "utils/date_time.h"
 
-namespace {
-const uint64_t kDeltaEpochInMicrosecs = 11644473600000000;
-}
-
 namespace date_time {
 
 TimevalStruct DateTime::getCurrentTime() {
@@ -79,14 +75,14 @@ int64_t date_time::DateTime::getSecs(const TimevalStruct& time) {
 
 int64_t DateTime::getmSecs(const TimevalStruct& time) {
   const TimevalStruct times = ConvertionUsecs(time);
-  return static_cast<int64_t>(times.tv_sec) * MILLISECONDS_IN_SECOND +
-         times.tv_usec / MICROSECONDS_IN_MILLISECONDS;
+  return static_cast<int64_t>(times.tv_sec) * kMillisecondsInSecond +
+         times.tv_usec / kMicrosecondsInMillisecond;
 }
 
 int64_t DateTime::getuSecs(const TimevalStruct& time) {
   const TimevalStruct times = ConvertionUsecs(time);
-  return static_cast<int64_t>(times.tv_sec) * MILLISECONDS_IN_SECOND *
-             MICROSECONDS_IN_MILLISECONDS +
+  return static_cast<int64_t>(times.tv_sec) * kMillisecondsInSecond *
+             kMicrosecondsInMillisecond +
          times.tv_usec;
 }
 
@@ -108,9 +104,9 @@ int64_t DateTime::calculateTimeDiff(const TimevalStruct& time1,
 }
 
 void DateTime::AddMilliseconds(TimevalStruct& time, uint32_t milliseconds) {
-  const uint32_t sec = milliseconds / MILLISECONDS_IN_SECOND;
+  const uint32_t sec = milliseconds / kMillisecondsInSecond;
   const uint32_t usec =
-      (milliseconds % MILLISECONDS_IN_SECOND) * MICROSECONDS_IN_MILLISECONDS;
+      (milliseconds % kMillisecondsInSecond) * kMicrosecondsInMillisecond;
   time.tv_sec += sec;
   time.tv_usec += usec;
   time = ConvertionUsecs(time);
@@ -159,11 +155,11 @@ TimeCompare date_time::DateTime::compareTime(const TimevalStruct& time1,
 }
 
 TimevalStruct date_time::DateTime::ConvertionUsecs(const TimevalStruct& time) {
-  if (time.tv_usec >= MICROSECONDS_IN_SECOND) {
+  if (time.tv_usec >= kMicrosecondsInSecond) {
     TimevalStruct time1;
     time1.tv_sec = static_cast<int64_t>(time.tv_sec) +
-                   (time.tv_usec / MICROSECONDS_IN_SECOND);
-    time1.tv_usec = static_cast<int64_t>(time.tv_usec) % MICROSECONDS_IN_SECOND;
+                   (time.tv_usec / kMicrosecondsInSecond);
+    time1.tv_usec = static_cast<int64_t>(time.tv_usec) % kMicrosecondsInSecond;
     return time1;
   }
   return time;

--- a/src/components/utils/src/file_system_posix.cc
+++ b/src/components/utils/src/file_system_posix.cc
@@ -55,7 +55,7 @@ uint64_t file_system::GetAvailableDiskSpace(const std::string& utf8_path) {
   }
 }
 
-int64_t file_system::FileSize(const std::string& utf8_path) {
+uint64_t file_system::FileSize(const std::string& utf8_path) {
   if (file_system::FileExists(utf8_path)) {
     struct stat file_info = {0};
     stat(utf8_path.c_str(), &file_info);
@@ -64,8 +64,8 @@ int64_t file_system::FileSize(const std::string& utf8_path) {
   return 0;
 }
 
-size_t file_system::DirectorySize(const std::string& utf8_path) {
-  size_t size = 0;
+uint64_t file_system::DirectorySize(const std::string& utf8_path) {
+  uint64_t size = 0;
   int32_t return_code = 0;
   DIR* directory = NULL;
 

--- a/src/components/utils/src/file_system_posix.cc
+++ b/src/components/utils/src/file_system_posix.cc
@@ -449,6 +449,14 @@ std::string file_system::ConcatPath(const std::string& utf8_path1,
   return ConcatPath(ConcatPath(utf8_path1, utf8_path2), utf8_path3);
 }
 
+std::string file_system::ConcatCurrentWorkingPath(
+    const std::string& utf8_path) {
+  if (!IsRelativePath(utf8_path)) {
+    return utf8_path;
+  }
+  return ConcatPath(CurrentWorkingDirectory(), utf8_path);
+}
+
 std::string file_system::RetrieveFileNameFromPath(
     const std::string& utf8_path) {
   std::size_t slash_pos = utf8_path.find_last_of("/", utf8_path.length());

--- a/src/components/utils/src/file_system_posix.cc
+++ b/src/components/utils/src/file_system_posix.cc
@@ -117,7 +117,7 @@ bool file_system::CreateDirectoryRecursively(const std::string& utf8_path) {
   bool ret_val = true;
 
   while (ret_val == true && pos <= utf8_path.length()) {
-    pos = utf8_path.find('/', pos + 1);
+    pos = utf8_path.find(GetPathDelimiter(), pos + 1);
     if (!DirectoryExists(utf8_path.substr(0, pos))) {
       if (0 != mkdir(utf8_path.substr(0, pos).c_str(), S_IRWXU)) {
         ret_val = false;

--- a/src/components/utils/src/file_system_posix.cc
+++ b/src/components/utils/src/file_system_posix.cc
@@ -89,7 +89,7 @@ uint64_t file_system::DirectorySize(const std::string& utf8_path) {
         continue;
       }
       std::string full_element_path = ConcatPath(utf8_path, result->d_name);
-      if (file_system::IsDirectory(full_element_path)) {
+      if (file_system::DirectoryExists(full_element_path)) {
         size += DirectorySize(full_element_path);
       } else {
         stat(full_element_path.c_str(), &file_info);
@@ -126,16 +126,6 @@ bool file_system::CreateDirectoryRecursively(const std::string& utf8_path) {
   }
 
   return ret_val;
-}
-
-bool file_system::IsDirectory(const std::string& utf8_path) {
-  struct stat status = {0};
-
-  if (-1 == stat(utf8_path.c_str(), &status)) {
-    return false;
-  }
-
-  return S_ISDIR(status.st_mode);
 }
 
 bool file_system::DirectoryExists(const std::string& utf8_path) {
@@ -238,7 +228,7 @@ void file_system::RemoveDirectoryContent(const std::string& utf8_path) {
       }
 
       std::string full_element_path = ConcatPath(utf8_path, result->d_name);
-      if (file_system::IsDirectory(full_element_path)) {
+      if (file_system::DirectoryExists(full_element_path)) {
         RemoveDirectoryContent(full_element_path);
         rmdir(full_element_path.c_str());
       } else {

--- a/src/components/utils/src/file_system_posix.cc
+++ b/src/components/utils/src/file_system_posix.cc
@@ -390,7 +390,7 @@ uint64_t file_system::GetFileModificationTime(const std::string& utf8_path) {
   struct stat info;
   stat(utf8_path.c_str(), &info);
 #ifndef __QNXNTO__
-  return static_cast<uint64_t>(info.st_mtim.tv_nsec);
+  return static_cast<uint64_t>(info.st_mtim.tv_sec);
 #else
   return static_cast<uint64_t>(info.st_mtime);
 #endif

--- a/src/components/utils/src/file_system_posix.cc
+++ b/src/components/utils/src/file_system_posix.cc
@@ -445,13 +445,6 @@ bool file_system::IsRelativePath(const std::string& utf8_path) {
   return '/' != utf8_path[0];
 }
 
-void file_system::MakeAbsolutePath(std::string& utf8_path) {
-  if (!IsRelativePath(utf8_path)) {
-    return;
-  }
-  utf8_path = ConcatPath(CurrentWorkingDirectory(), utf8_path);
-}
-
 std::string file_system::GetPathDelimiter() {
   return "/";
 }

--- a/src/components/utils/src/file_system_posix.cc
+++ b/src/components/utils/src/file_system_posix.cc
@@ -46,26 +46,28 @@
 
 CREATE_LOGGERPTR_GLOBAL(logger_, "Utils")
 
-uint64_t file_system::GetAvailableDiskSpace(const std::string& utf8_path) {
+file_system::FileSizeType file_system::GetAvailableDiskSpace(
+    const std::string& utf8_path) {
   struct statvfs fsInfo = {0};
   if (statvfs(utf8_path.c_str(), &fsInfo) == 0) {
     return fsInfo.f_bsize * fsInfo.f_bfree;
   } else {
-    return 0;
+    return 0u;
   }
 }
 
-uint64_t file_system::FileSize(const std::string& utf8_path) {
+file_system::FileSizeType file_system::FileSize(const std::string& utf8_path) {
   if (file_system::FileExists(utf8_path)) {
     struct stat file_info = {0};
     stat(utf8_path.c_str(), &file_info);
     return file_info.st_size;
   }
-  return 0;
+  return 0u;
 }
 
-uint64_t file_system::DirectorySize(const std::string& utf8_path) {
-  uint64_t size = 0;
+file_system::FileSizeType file_system::DirectorySize(
+    const std::string& utf8_path) {
+  FileSizeType size = 0u;
   int32_t return_code = 0;
   DIR* directory = NULL;
 

--- a/src/components/utils/src/file_system_posix.cc
+++ b/src/components/utils/src/file_system_posix.cc
@@ -160,40 +160,34 @@ bool file_system::FileExists(const std::string& utf8_path) {
 bool file_system::Write(const std::string& utf8_path,
                         const std::vector<uint8_t>& data,
                         std::ios_base::openmode mode) {
-  std::ofstream file(utf8_path.c_str(), std::ios_base::binary | mode);
-  if (file.is_open()) {
-    for (uint32_t i = 0; i < data.size(); ++i) {
-      file << data[i];
-    }
-    file.close();
-    return true;
+  std::ofstream file(utf8_path, std::ios_base::binary | mode);
+  if (!file.is_open()) {
+    return false;
   }
-  return false;
+  file.write(reinterpret_cast<const char*>(&data[0]), data.size());
+  file.close();
+  return file.good();
 }
 
 std::ofstream* file_system::Open(const std::string& utf8_path,
                                  std::ios_base::openmode mode) {
   std::ofstream* file = new std::ofstream();
-  file->open(utf8_path.c_str(), std::ios_base::binary | mode);
-  if (file->is_open()) {
-    return file;
+  file->open(utf8_path, std::ios_base::binary | mode);
+  if (!file->is_open()) {
+    delete file;
+    return NULL;
   }
-
-  delete file;
-  return NULL;
+  return file;
 }
 
 bool file_system::Write(std::ofstream* const file_stream,
                         const uint8_t* data,
-                        uint32_t data_size) {
-  bool result = false;
-  if (file_stream) {
-    for (size_t i = 0; i < data_size; ++i) {
-      (*file_stream) << data[i];
-    }
-    result = true;
+                        size_t data_size) {
+  if (!file_stream) {
+    return false;
   }
-  return result;
+  file_stream->write(reinterpret_cast<const char*>(&data[0]), data_size);
+  return file_stream->good();
 }
 
 void file_system::Close(std::ofstream* file_stream) {
@@ -326,11 +320,10 @@ std::vector<std::string> file_system::ListFiles(const std::string& utf8_path) {
 }
 
 bool file_system::WriteBinaryFile(const std::string& utf8_path,
-                                  const std::vector<uint8_t>& contents) {
+                                  const std::vector<uint8_t>& data) {
   using namespace std;
   ofstream output(utf8_path.c_str(), ios_base::binary | ios_base::trunc);
-  output.write(reinterpret_cast<const char*>(&contents.front()),
-               contents.size());
+  output.write(reinterpret_cast<const char*>(&data.front()), data.size());
   return output.good();
 }
 

--- a/src/components/utils/src/file_system_posix.cc
+++ b/src/components/utils/src/file_system_posix.cc
@@ -51,9 +51,8 @@ file_system::FileSizeType file_system::GetAvailableDiskSpace(
   struct statvfs fsInfo = {0};
   if (statvfs(utf8_path.c_str(), &fsInfo) == 0) {
     return fsInfo.f_bsize * fsInfo.f_bfree;
-  } else {
-    return 0u;
   }
+  return 0u;
 }
 
 file_system::FileSizeType file_system::FileSize(const std::string& utf8_path) {
@@ -152,6 +151,9 @@ bool file_system::FileExists(const std::string& utf8_path) {
 bool file_system::Write(const std::string& utf8_path,
                         const std::vector<uint8_t>& data,
                         std::ios_base::openmode mode) {
+  if (0 == data.size()) {
+    return false;
+  }
   std::ofstream file(utf8_path, std::ios_base::binary | mode);
   if (!file.is_open()) {
     return false;
@@ -175,7 +177,7 @@ std::ofstream* file_system::Open(const std::string& utf8_path,
 bool file_system::Write(std::ofstream* const file_stream,
                         const uint8_t* data,
                         std::size_t data_size) {
-  if (!file_stream) {
+  if (!file_stream || !data) {
     return false;
   }
   file_stream->write(reinterpret_cast<const char*>(&data[0]), data_size);
@@ -313,9 +315,12 @@ std::vector<std::string> file_system::ListFiles(const std::string& utf8_path) {
 
 bool file_system::WriteBinaryFile(const std::string& utf8_path,
                                   const std::vector<uint8_t>& data) {
-  using namespace std;
-  ofstream output(utf8_path.c_str(), ios_base::binary | ios_base::trunc);
-  output.write(reinterpret_cast<const char*>(&data.front()), data.size());
+  if (0 == data.size()) {
+    return false;
+  }
+  std::ofstream output(utf8_path.c_str(),
+                       std::ios_base::binary | std::ios_base::trunc);
+  output.write(reinterpret_cast<const char*>(&data[0]), data.size());
   return output.good();
 }
 

--- a/src/components/utils/src/file_system_posix.cc
+++ b/src/components/utils/src/file_system_posix.cc
@@ -113,7 +113,7 @@ std::string file_system::CreateDirectory(const std::string& utf8_path) {
 }
 
 bool file_system::CreateDirectoryRecursively(const std::string& utf8_path) {
-  size_t pos = 0;
+  std::size_t pos = 0;
   bool ret_val = true;
 
   while (ret_val == true && pos <= utf8_path.length()) {
@@ -172,7 +172,7 @@ std::ofstream* file_system::Open(const std::string& utf8_path,
 
 bool file_system::Write(std::ofstream* const file_stream,
                         const uint8_t* data,
-                        size_t data_size) {
+                        std::size_t data_size) {
   if (!file_stream) {
     return false;
   }
@@ -187,7 +187,7 @@ void file_system::Close(std::ofstream* file_stream) {
 }
 
 std::string file_system::CurrentWorkingDirectory() {
-  const size_t filename_max_length = 1024;
+  const std::size_t filename_max_length = 1024;
   char path[filename_max_length];
   if (0 == getcwd(path, filename_max_length)) {
     LOG4CXX_WARN(logger_, "Could not get CWD");
@@ -358,7 +358,7 @@ const std::string file_system::ConvertPathForURL(const std::string& utf8_path) {
     it_sym = reserved_symbols.begin();
     for (; it_sym != it_sym_end; ++it_sym) {
       if (*it_path == *it_sym) {
-        const size_t size = 100;
+        const std::size_t size = 100;
         char percent_value[size];
         snprintf(percent_value, size, "%%%x", *it_path);
         converted_path += percent_value;
@@ -444,8 +444,8 @@ std::string file_system::ConcatPath(const std::string& utf8_path1,
 
 std::string file_system::RetrieveFileNameFromPath(
     const std::string& utf8_path) {
-  size_t slash_pos = utf8_path.find_last_of("/", utf8_path.length());
-  size_t back_slash_pos = utf8_path.find_last_of("\\", utf8_path.length());
+  std::size_t slash_pos = utf8_path.find_last_of("/", utf8_path.length());
+  std::size_t back_slash_pos = utf8_path.find_last_of("\\", utf8_path.length());
   return utf8_path.substr(
       std::max(slash_pos != std::string::npos ? slash_pos + 1 : 0,
                back_slash_pos != std::string::npos ? back_slash_pos + 1 : 0));

--- a/src/components/utils/src/file_system_posix.cc
+++ b/src/components/utils/src/file_system_posix.cc
@@ -151,7 +151,7 @@ bool file_system::FileExists(const std::string& utf8_path) {
 bool file_system::Write(const std::string& utf8_path,
                         const std::vector<uint8_t>& data,
                         std::ios_base::openmode mode) {
-  if (0 == data.size()) {
+  if (data.empty()) {
     return false;
   }
   std::ofstream file(utf8_path, std::ios_base::binary | mode);
@@ -315,7 +315,7 @@ std::vector<std::string> file_system::ListFiles(const std::string& utf8_path) {
 
 bool file_system::WriteBinaryFile(const std::string& utf8_path,
                                   const std::vector<uint8_t>& data) {
-  if (0 == data.size()) {
+  if (data.empty()) {
     return false;
   }
   std::ofstream output(utf8_path.c_str(),

--- a/src/components/utils/src/file_system_qt.cc
+++ b/src/components/utils/src/file_system_qt.cc
@@ -111,11 +111,6 @@ bool file_system::CreateDirectoryRecursively(const std::string& utf8_path) {
   return dir.mkpath(QString(utf8_path.c_str()));
 }
 
-bool file_system::IsDirectory(const std::string& utf8_path) {
-  QFileInfo checkFile(QString(utf8_path.c_str()));
-  return checkFile.isDir();
-}
-
 bool file_system::DirectoryExists(const std::string& utf8_path) {
   QFileInfo checkFile(QString(utf8_path.c_str()));
   return checkFile.exists() && checkFile.isDir();

--- a/src/components/utils/src/file_system_qt.cc
+++ b/src/components/utils/src/file_system_qt.cc
@@ -74,11 +74,8 @@ file_system::FileSizeType file_system::GetAvailableDiskSpace(
 }
 
 file_system::FileSizeType file_system::FileSize(const std::string& utf8_path) {
-  if (file_system::FileExists(utf8_path)) {
-    return static_cast<FileSizeType>(
-        QFileInfo(QString(utf8_path.c_str())).size());
-  }
-  return 0u;
+  return static_cast<FileSizeType>(
+      QFileInfo(QString(utf8_path.c_str())).size());
 }
 
 file_system::FileSizeType file_system::DirectorySize(

--- a/src/components/utils/src/file_system_qt.cc
+++ b/src/components/utils/src/file_system_qt.cc
@@ -53,7 +53,7 @@ namespace {
   * Path prefix required by OS Windows to allow
   * processing file names longer than MAX_PATH (260) characters
   */
-const std::string kPlatformPathPrefix = "\\\\?\\";
+const QString kPlatformPathPrefix = QString::fromUtf8("\\\\?\\");
 
 /**
   * @brief Converts UTF-8 string to wide string
@@ -64,7 +64,8 @@ std::wstring ConvertUTF8ToWString(const std::string& utf8_str) {
   if (utf8_str.empty()) {
     return std::wstring();
   }
-  QString extended_utf8_str(utils::ReplaceString(utf8_str, "/", "\\").c_str());
+  QString extended_utf8_str =
+      QString::fromUtf8(utils::ReplaceString(utf8_str, "/", "\\").c_str());
   if (!file_system::IsRelativePath(utf8_str)) {
     extended_utf8_str = kPlatformPathPrefix + extended_utf8_str;
   }
@@ -75,22 +76,22 @@ std::wstring ConvertUTF8ToWString(const std::string& utf8_str) {
 
 file_system::FileSizeType file_system::GetAvailableDiskSpace(
     const std::string& utf8_path) {
-  QStorageInfo mstor(QString(utf8_path.c_str()));
+  QStorageInfo mstor(QString::fromUtf8(utf8_path.c_str()));
   qint64 b_aval = mstor.bytesAvailable();
   return static_cast<FileSizeType>(b_aval);
 }
 
 file_system::FileSizeType file_system::FileSize(const std::string& utf8_path) {
   return static_cast<FileSizeType>(
-      QFileInfo(QString(utf8_path.c_str())).size());
+      QFileInfo(QString::fromUtf8(utf8_path.c_str())).size());
 }
 
 file_system::FileSizeType file_system::DirectorySize(
     const std::string& utf8_path) {
   FileSizeType size = 0u;
-  QFileInfo str_info(QString(utf8_path.c_str()));
+  QFileInfo str_info(QString::fromUtf8(utf8_path.c_str()));
   if (str_info.isDir()) {
-    QDir dir(QString(utf8_path.c_str()));
+    QDir dir(QString::fromUtf8(utf8_path.c_str()));
     QFileInfoList list =
         dir.entryInfoList(QDir::Files | QDir::Dirs | QDir::Hidden |
                           QDir::NoSymLinks | QDir::NoDotAndDotDot);
@@ -107,7 +108,7 @@ file_system::FileSizeType file_system::DirectorySize(
 
 std::string file_system::CreateDirectory(const std::string& utf8_path) {
   QDir dir;
-  if (dir.mkdir(QString(utf8_path.c_str()))) {
+  if (dir.mkdir(QString::fromUtf8(utf8_path.c_str()))) {
     return utf8_path;
   }
   return "";
@@ -115,16 +116,16 @@ std::string file_system::CreateDirectory(const std::string& utf8_path) {
 
 bool file_system::CreateDirectoryRecursively(const std::string& utf8_path) {
   QDir dir;
-  return dir.mkpath(QString(utf8_path.c_str()));
+  return dir.mkpath(QString::fromUtf8(utf8_path.c_str()));
 }
 
 bool file_system::DirectoryExists(const std::string& utf8_path) {
-  QFileInfo checkFile(QString(utf8_path.c_str()));
+  QFileInfo checkFile(QString::fromUtf8(utf8_path.c_str()));
   return checkFile.exists() && checkFile.isDir();
 }
 
 bool file_system::FileExists(const std::string& utf8_path) {
-  QFileInfo checkFile(QString(utf8_path.c_str()));
+  QFileInfo checkFile(QString::fromUtf8(utf8_path.c_str()));
   return checkFile.exists() && checkFile.isFile();
 }
 
@@ -177,33 +178,33 @@ std::string file_system::CurrentWorkingDirectory() {
 
 bool file_system::DeleteFile(const std::string& utf8_path) {
   if (FileExists(utf8_path) && IsAccessible(utf8_path, W_OK)) {
-    return QFile::remove(QString(utf8_path.c_str()));
+    return QFile::remove(QString::fromUtf8(utf8_path.c_str()));
   }
   return false;
 }
 
 void file_system::RemoveDirectoryContent(const std::string& utf8_path) {
-  QDir dir(QString(utf8_path.c_str()));
+  QDir dir(QString::fromUtf8(utf8_path.c_str()));
   dir.setNameFilters(QStringList() << "*.*");
   dir.setFilter(QDir::Files);
   foreach (QString dirFile, dir.entryList()) { dir.remove(dirFile); }
-  dir.rmpath(QString(utf8_path.c_str()));
+  dir.rmpath(QString::fromUtf8(utf8_path.c_str()));
 }
 
 bool file_system::RemoveDirectory(const std::string& utf8_path,
                                   bool is_recursively) {
-  QDir dir(QString(utf8_path.c_str()));
+  QDir dir(QString::fromUtf8(utf8_path.c_str()));
   if (DirectoryExists(utf8_path) && IsAccessible(utf8_path, W_OK)) {
     if (is_recursively) {
       return dir.removeRecursively();
     }
-    return dir.rmdir(QString(utf8_path.c_str()));
+    return dir.rmdir(QString::fromUtf8(utf8_path.c_str()));
   }
   return false;
 }
 
 bool file_system::IsAccessible(const std::string& utf8_path, int32_t how) {
-  QFileInfo qFileInfo(QString(utf8_path.c_str()));
+  QFileInfo qFileInfo(QString::fromUtf8(utf8_path.c_str()));
   switch (how) {
     case (W_OK):
       return qFileInfo.isWritable();
@@ -227,7 +228,7 @@ std::vector<std::string> file_system::ListFiles(const std::string& utf8_path) {
   if (!DirectoryExists(utf8_path)) {
     return listFiles;
   }
-  QDir dir(QString(utf8_path.c_str()));
+  QDir dir(QString::fromUtf8(utf8_path.c_str()));
   QStringList list_files = dir.entryList(QDir::Files);
   foreach (QString str, list_files) { listFiles.push_back(str.toStdString()); }
   return listFiles;
@@ -238,7 +239,7 @@ bool file_system::WriteBinaryFile(const std::string& utf8_path,
   if (0 == data.size()) {
     return false;
   }
-  QFile file(QString(utf8_path.c_str()));
+  QFile file(QString::fromUtf8(utf8_path.c_str()));
   if (!file.open(QIODevice::WriteOnly)) {
     return false;
   }
@@ -248,7 +249,7 @@ bool file_system::WriteBinaryFile(const std::string& utf8_path,
 
 bool file_system::ReadBinaryFile(const std::string& utf8_path,
                                  std::vector<uint8_t>& result) {
-  QFile file(QString(utf8_path.c_str()));
+  QFile file(QString::fromUtf8(utf8_path.c_str()));
   if (!file.open(QIODevice::ReadOnly)) {
     return false;
   }
@@ -259,7 +260,7 @@ bool file_system::ReadBinaryFile(const std::string& utf8_path,
 }
 
 bool file_system::ReadFile(const std::string& utf8_path, std::string& result) {
-  QFile file(QString(utf8_path.c_str()));
+  QFile file(QString::fromUtf8(utf8_path.c_str()));
   if (!file.open(QIODevice::Text)) {
     return false;
   }
@@ -269,17 +270,17 @@ bool file_system::ReadFile(const std::string& utf8_path, std::string& result) {
 }
 
 const std::string file_system::ConvertPathForURL(const std::string& utf8_path) {
-  QString p(utf8_path.c_str());
+  QString p(QString::fromUtf8(utf8_path.c_str()));
   return QUrl::fromLocalFile(p).url().toStdString();
 }
 
 bool file_system::CreateFile(const std::string& utf8_path) {
-  QFile file(QString(utf8_path.c_str()));
-  return file.open(QIODevice::WriteOnly));
+  QFile file(QString::fromUtf8(utf8_path.c_str()));
+  return file.open(QIODevice::WriteOnly);
 }
 
 uint64_t file_system::GetFileModificationTime(const std::string& utf8_path) {
-  QFileInfo f(QString(utf8_path.c_str()));
+  QFileInfo f(QString::fromUtf8(utf8_path.c_str()));
   return static_cast<uint64_t>(f.lastModified().toMSecsSinceEpoch() /
                                date_time::kMillisecondsInSecond);
 }
@@ -290,8 +291,8 @@ bool file_system::CopyFile(const std::string& utf8_src_path,
       !CreateFile(utf8_dst_path)) {
     return false;
   }
-  return QFile::copy(QString(utf8_src_path.c_str()),
-                     QString(utf8_dst_path.c_str()));
+  return QFile::copy(QString::fromUtf8(utf8_src_path.c_str()),
+                     QString::fromUtf8(utf8_dst_path.c_str()));
 }
 
 bool file_system::MoveFile(const std::string& utf8_src_path,

--- a/src/components/utils/src/file_system_qt.cc
+++ b/src/components/utils/src/file_system_qt.cc
@@ -265,10 +265,7 @@ const std::string file_system::ConvertPathForURL(const std::string& utf8_path) {
 
 bool file_system::CreateFile(const std::string& utf8_path) {
   QFile file(QString(utf8_path.c_str()));
-  if (!file.open(QIODevice::WriteOnly)) {
-    return false;
-  }
-  return true;
+  return file.open(QIODevice::WriteOnly));
 }
 
 uint64_t file_system::GetFileModificationTime(const std::string& utf8_path) {

--- a/src/components/utils/src/file_system_qt.cc
+++ b/src/components/utils/src/file_system_qt.cc
@@ -310,13 +310,6 @@ bool file_system::IsRelativePath(const std::string& utf8_path) {
   return QDir::isRelativePath(utf8_path.c_str());
 }
 
-void file_system::MakeAbsolutePath(std::string& utf8_path) {
-  if (!IsRelativePath(utf8_path)) {
-    return;
-  }
-  utf8_path = ConcatPath(CurrentWorkingDirectory(), utf8_path);
-}
-
 std::string file_system::ConcatPath(const std::string& utf8_path1,
                                     const std::string& utf8_path2) {
   return utf8_path1 + GetPathDelimiter() + utf8_path2;

--- a/src/components/utils/src/file_system_qt.cc
+++ b/src/components/utils/src/file_system_qt.cc
@@ -32,6 +32,7 @@
 #include "utils/file_system.h"
 #include "utils/logger.h"
 #include "utils/string_utils.h"
+#include "utils/date_time.h"
 
 #include <QtCore>
 #include <QStorageInfo>
@@ -267,7 +268,8 @@ bool file_system::CreateFile(const std::string& utf8_path) {
 
 uint64_t file_system::GetFileModificationTime(const std::string& utf8_path) {
   QFileInfo f(QString(utf8_path.c_str()));
-  return static_cast<uint64_t>(f.lastModified().toMSecsSinceEpoch());
+  return static_cast<uint64_t>(f.lastModified().toMSecsSinceEpoch() /
+                               date_time::kMillisecondsInSecond);
 }
 
 bool file_system::CopyFile(const std::string& utf8_src_path,

--- a/src/components/utils/src/file_system_qt.cc
+++ b/src/components/utils/src/file_system_qt.cc
@@ -72,14 +72,14 @@ uint64_t file_system::GetAvailableDiskSpace(const std::string& utf8_path) {
   return static_cast<uint64_t>(b_aval);
 }
 
-int64_t file_system::FileSize(const std::string& utf8_path) {
+uint64_t file_system::FileSize(const std::string& utf8_path) {
   if (file_system::FileExists(utf8_path)) {
-    return static_cast<int64_t>(QFileInfo(QString(utf8_path.c_str())).size());
+    return static_cast<uint64_t>(QFileInfo(QString(utf8_path.c_str())).size());
   }
   return 0;
 }
 
-size_t file_system::DirectorySize(const std::string& utf8_path) {
+uint64_t file_system::DirectorySize(const std::string& utf8_path) {
   quint64 size = 0;
   QFileInfo str_info(QString(utf8_path.c_str()));
   if (str_info.isDir()) {
@@ -95,7 +95,7 @@ size_t file_system::DirectorySize(const std::string& utf8_path) {
       }
     }
   }
-  return static_cast<size_t>(size);
+  return static_cast<uint64_t>(size);
 }
 
 std::string file_system::CreateDirectory(const std::string& utf8_path) {

--- a/src/components/utils/src/file_system_qt.cc
+++ b/src/components/utils/src/file_system_qt.cc
@@ -132,7 +132,7 @@ bool file_system::FileExists(const std::string& utf8_path) {
 bool file_system::Write(const std::string& utf8_path,
                         const std::vector<uint8_t>& data,
                         std::ios_base::openmode mode) {
-  if (0 == data.size()) {
+  if (data.empty()) {
     return false;
   }
   std::ofstream file(ConvertUTF8ToWString(utf8_path),
@@ -236,7 +236,7 @@ std::vector<std::string> file_system::ListFiles(const std::string& utf8_path) {
 
 bool file_system::WriteBinaryFile(const std::string& utf8_path,
                                   const std::vector<uint8_t>& data) {
-  if (0 == data.size()) {
+  if (data.empty()) {
     return false;
   }
   QFile file(QString::fromUtf8(utf8_path.c_str()));

--- a/src/components/utils/src/file_system_qt.cc
+++ b/src/components/utils/src/file_system_qt.cc
@@ -66,21 +66,24 @@ std::wstring ConvertUTF8ToWString(const std::string& utf8_str) {
 
 }  // namespace
 
-uint64_t file_system::GetAvailableDiskSpace(const std::string& utf8_path) {
+file_system::FileSizeType file_system::GetAvailableDiskSpace(
+    const std::string& utf8_path) {
   QStorageInfo mstor(QString(utf8_path.c_str()));
   qint64 b_aval = mstor.bytesAvailable();
-  return static_cast<uint64_t>(b_aval);
+  return static_cast<FileSizeType>(b_aval);
 }
 
-uint64_t file_system::FileSize(const std::string& utf8_path) {
+file_system::FileSizeType file_system::FileSize(const std::string& utf8_path) {
   if (file_system::FileExists(utf8_path)) {
-    return static_cast<uint64_t>(QFileInfo(QString(utf8_path.c_str())).size());
+    return static_cast<FileSizeType>(
+        QFileInfo(QString(utf8_path.c_str())).size());
   }
-  return 0;
+  return 0u;
 }
 
-uint64_t file_system::DirectorySize(const std::string& utf8_path) {
-  quint64 size = 0;
+file_system::FileSizeType file_system::DirectorySize(
+    const std::string& utf8_path) {
+  FileSizeType size = 0u;
   QFileInfo str_info(QString(utf8_path.c_str()));
   if (str_info.isDir()) {
     QDir dir(QString(utf8_path.c_str()));
@@ -91,11 +94,11 @@ uint64_t file_system::DirectorySize(const std::string& utf8_path) {
       if (fileInfo.isDir()) {
         size += DirectorySize(fileInfo.absoluteFilePath().toStdString());
       } else {
-        size += fileInfo.size();
+        size += static_cast<FileSizeType>(fileInfo.size());
       }
     }
   }
-  return static_cast<uint64_t>(size);
+  return size;
 }
 
 std::string file_system::CreateDirectory(const std::string& utf8_path) {

--- a/src/components/utils/src/file_system_qt.cc
+++ b/src/components/utils/src/file_system_qt.cc
@@ -147,7 +147,7 @@ std::ofstream* file_system::Open(const std::string& utf8_path,
 
 bool file_system::Write(std::ofstream* const file_stream,
                         const uint8_t* data,
-                        size_t data_size) {
+                        std::size_t data_size) {
   if (!file_stream) {
     return false;
   }

--- a/src/components/utils/src/file_system_qt.cc
+++ b/src/components/utils/src/file_system_qt.cc
@@ -325,6 +325,14 @@ std::string file_system::ConcatPath(const std::string& utf8_path1,
   return ConcatPath(ConcatPath(utf8_path1, utf8_path2), utf8_path3);
 }
 
+std::string file_system::ConcatCurrentWorkingPath(
+    const std::string& utf8_path) {
+  if (!IsRelativePath(utf8_path)) {
+    return utf8_path;
+  }
+  return ConcatPath(CurrentWorkingDirectory(), utf8_path);
+}
+
 std::string file_system::RetrieveFileNameFromPath(
     const std::string& utf8_path) {
   QFile fname(utf8_path.c_str());

--- a/src/components/utils/src/file_system_qt.cc
+++ b/src/components/utils/src/file_system_qt.cc
@@ -33,9 +33,6 @@
 #include "utils/logger.h"
 #include "utils/string_utils.h"
 
-#include <sys/stat.h>
-#include <sys/types.h>
-#include <sstream>
 #include <QtCore>
 #include <QStorageInfo>
 #include <QDir>
@@ -43,15 +40,31 @@
 #include <QFileInfo>
 #include <QUrl>
 
-#include <io.h>
 #include <fstream>
 #include <cstddef>
-#include <algorithm>
 
 #define R_OK 4
 #define W_OK 2
 
-CREATE_LOGGERPTR_GLOBAL(logger_, "Utils")
+namespace {
+
+/**
+  * @brief Converts UTF-8 string to wide string
+  * @param str String to be converted
+  * @return Result wide string
+  */
+std::wstring ConvertUTF8ToWString(const std::string& utf8_str) {
+  if (utf8_str.empty()) {
+    return std::wstring();
+  }
+  QString extended_utf8_str(utils::ReplaceString(utf8_str, "/", "\\").c_str());
+  if (!file_system::IsRelativePath(utf8_str)) {
+    extended_utf8_str = "\\\\?\\" + extended_utf8_str;
+  }
+  return extended_utf8_str.toStdWString();
+}
+
+}  // namespace
 
 uint64_t file_system::GetAvailableDiskSpace(const std::string& utf8_path) {
   QStorageInfo mstor(QString(utf8_path.c_str()));
@@ -116,41 +129,35 @@ bool file_system::FileExists(const std::string& utf8_path) {
 bool file_system::Write(const std::string& utf8_path,
                         const std::vector<uint8_t>& data,
                         std::ios_base::openmode mode) {
-  QByteArray text(reinterpret_cast<uint8_t>(data.data()), data.size());
-  QFile file(QString(utf8_path.c_str()));
-  file.open(QIODevice::WriteOnly | static_cast<QIODevice::OpenModeFlag>(mode));
-  if (file.isOpen()) {
-    file.write(text);
-    file.close();
-    return true;
+  std::ofstream file(ConvertUTF8ToWString(utf8_path),
+                     std::ios_base::binary | mode);
+  if (!file.is_open()) {
+    return false;
   }
-  return false;
+  file.write(reinterpret_cast<const char*>(&data[0]), data.size());
+  file.close();
+  return file.good();
 }
 
 std::ofstream* file_system::Open(const std::string& utf8_path,
                                  std::ios_base::openmode mode) {
   std::ofstream* file = new std::ofstream();
-  file->open(QString(utf8_path.c_str()).toStdWString(),
-             std::ios_base::binary | mode);
-  if (file->is_open()) {
-    return file;
+  file->open(ConvertUTF8ToWString(utf8_path), std::ios_base::binary | mode);
+  if (!file->is_open()) {
+    delete file;
+    return NULL;
   }
-
-  delete file;
-  return NULL;
+  return file;
 }
 
 bool file_system::Write(std::ofstream* const file_stream,
                         const uint8_t* data,
-                        uint32_t data_size) {
-  bool result = false;
-  if (file_stream) {
-    for (size_t i = 0; i < data_size; ++i) {
-      (*file_stream) << data[i];
-    }
-    result = true;
+                        size_t data_size) {
+  if (!file_stream) {
+    return false;
   }
-  return result;
+  file_stream->write(reinterpret_cast<const char*>(&data[0]), data_size);
+  return file_stream->good();
 }
 
 void file_system::Close(std::ofstream* file_stream) {
@@ -222,41 +229,34 @@ std::vector<std::string> file_system::ListFiles(const std::string& utf8_path) {
 }
 
 bool file_system::WriteBinaryFile(const std::string& utf8_path,
-                                  const std::vector<uint8_t>& contents) {
-  using namespace std;
-  ofstream output(QString(utf8_path.c_str()).toStdWString(),
-                  ios_base::binary | ios_base::trunc);
-  output.write(reinterpret_cast<const char*>(&contents.front()),
-               contents.size());
-  return output.good();
+                                  const std::vector<uint8_t>& data) {
+  QFile file(QString(utf8_path.c_str()));
+  if (!file.open(QIODevice::WriteOnly)) {
+    return false;
+  }
+  return data.size() ==
+         file.write(reinterpret_cast<const char*>(&data[0]), data.size());
 }
 
 bool file_system::ReadBinaryFile(const std::string& utf8_path,
                                  std::vector<uint8_t>& result) {
-  if (!FileExists(utf8_path) || !IsAccessible(utf8_path, R_OK)) {
+  QFile file(QString(utf8_path.c_str()));
+  if (!file.open(QIODevice::ReadOnly)) {
     return false;
   }
-
-  std::ifstream file(QString(utf8_path.c_str()).toStdWString(),
-                     std::ios_base::binary);
-  std::ostringstream ss;
-  ss << file.rdbuf();
-  const std::string& s = ss.str();
-
-  result.resize(s.length());
-  std::copy(s.begin(), s.end(), result.begin());
+  QByteArray read = file.readAll();
+  const uint8_t* read_start = reinterpret_cast<uint8_t*>(read.data());
+  result = std::vector<uint8_t>(read_start, read_start + read.size());
   return true;
 }
 
 bool file_system::ReadFile(const std::string& utf8_path, std::string& result) {
-  if (!FileExists(utf8_path) || !IsAccessible(utf8_path, R_OK)) {
+  QFile file(QString(utf8_path.c_str()));
+  if (!file.open(QIODevice::Text)) {
     return false;
   }
-
-  std::ifstream file(QString(utf8_path.c_str()).toStdWString());
-  std::ostringstream ss;
-  ss << file.rdbuf();
-  result = ss.str();
+  QByteArray read = file.readAll();
+  result = std::string(read.data());
   return true;
 }
 
@@ -266,13 +266,11 @@ const std::string file_system::ConvertPathForURL(const std::string& utf8_path) {
 }
 
 bool file_system::CreateFile(const std::string& utf8_path) {
-  std::ofstream file(QString(utf8_path.c_str()).toStdWString());
-  if (!(file.is_open())) {
+  QFile file(QString(utf8_path.c_str()));
+  if (!file.open(QIODevice::WriteOnly)) {
     return false;
-  } else {
-    file.close();
-    return true;
   }
+  return true;
 }
 
 uint64_t file_system::GetFileModificationTime(const std::string& utf8_path) {

--- a/src/components/utils/src/file_system_win.cc
+++ b/src/components/utils/src/file_system_win.cc
@@ -489,6 +489,14 @@ std::string file_system::ConcatPath(const std::string& utf8_path1,
   return ConcatPath(ConcatPath(utf8_path1, utf8_path2), utf8_path3);
 }
 
+std::string file_system::ConcatCurrentWorkingPath(
+    const std::string& utf8_path) {
+  if (!IsRelativePath(utf8_path)) {
+    return utf8_path;
+  }
+  return ConcatPath(CurrentWorkingDirectory(), utf8_path);
+}
+
 std::string file_system::RetrieveFileNameFromPath(
     const std::string& utf8_path) {
   std::size_t slash_pos = utf8_path.find_last_of("/", utf8_path.length());

--- a/src/components/utils/src/file_system_win.cc
+++ b/src/components/utils/src/file_system_win.cc
@@ -106,7 +106,8 @@ std::string ConvertWStringToUTF8(const std::wstring& wide_str) {
 
 }  // namespace
 
-uint64_t file_system::GetAvailableDiskSpace(const std::string& utf8_path) {
+file_system::FileSizeType file_system::GetAvailableDiskSpace(
+    const std::string& utf8_path) {
   DWORD sectors_per_cluster;
   DWORD bytes_per_sector;
   DWORD number_of_free_clusters;
@@ -117,19 +118,19 @@ uint64_t file_system::GetAvailableDiskSpace(const std::string& utf8_path) {
                                      &number_of_free_clusters,
                                      NULL);
   if (0 == res) {
-    return 0;
+    return 0u;
   }
   return number_of_free_clusters * sectors_per_cluster * bytes_per_sector;
 }
 
-uint64_t file_system::FileSize(const std::string& utf8_path) {
+file_system::FileSizeType file_system::FileSize(const std::string& utf8_path) {
   WIN32_FIND_DATAW ffd;
   HANDLE find = FindFirstFileW(ConvertUTF8ToWString(utf8_path).c_str(), &ffd);
   if (INVALID_HANDLE_VALUE == find) {
-    return 0;
+    return 0u;
   }
 
-  uint64_t file_size = 0;
+  FileSizeType file_size = 0u;
   file_size |= ffd.nFileSizeHigh;
   file_size <<= 32;
   file_size |= ffd.nFileSizeLow;
@@ -138,8 +139,9 @@ uint64_t file_system::FileSize(const std::string& utf8_path) {
   return file_size;
 }
 
-uint64_t file_system::DirectorySize(const std::string& utf8_path) {
-  uint64_t size = 0;
+file_system::FileSizeType file_system::DirectorySize(
+    const std::string& utf8_path) {
+  FileSizeType size = 0u;
   if (!DirectoryExists(utf8_path)) {
     return size;
   }
@@ -160,7 +162,7 @@ uint64_t file_system::DirectorySize(const std::string& utf8_path) {
         size += DirectorySize(utf8_file_name);
       }
     } else {
-      uint64_t file_size = 0;
+      FileSizeType file_size = 0u;
       file_size |= ffd.nFileSizeHigh;
       file_size <<= 32;
       file_size |= ffd.nFileSizeLow;

--- a/src/components/utils/src/file_system_win.cc
+++ b/src/components/utils/src/file_system_win.cc
@@ -44,8 +44,6 @@
 #include "utils/file_system.h"
 #include "utils/string_utils.h"
 
-#pragma comment(lib, "Shlwapi.lib")
-
 namespace {
 
 /**
@@ -460,23 +458,7 @@ bool file_system::MoveFile(const std::string& utf8_src_path,
 }
 
 bool file_system::IsRelativePath(const std::string& utf8_path) {
-  return static_cast<bool>(PathIsRelative(utf8_path.c_str()));
-}
-
-void file_system::MakeAbsolutePath(std::string& utf8_path) {
-  TCHAR buffer[MAX_PATH];
-  // Handle the case when we receive abs linux path.
-  // Removal of the leading slash will allow to get
-  // correct path from the GetFullPathName
-  int offset = 0;
-  if (utf8_path.find("/") == 0) {
-    offset = 1;
-  }
-  const DWORD size =
-      GetFullPathName(utf8_path.c_str() + offset, MAX_PATH, buffer, NULL);
-  if (size != 0) {
-    utf8_path.assign(buffer);
-  }
+  return std::string::npos == utf8_path.find(":");
 }
 
 std::string file_system::GetPathDelimiter() {
@@ -487,6 +469,7 @@ std::string file_system::ConcatPath(const std::string& utf8_path1,
                                     const std::string& utf8_path2) {
   return utf8_path1 + GetPathDelimiter() + utf8_path2;
 }
+
 std::string file_system::ConcatPath(const std::string& utf8_path1,
                                     const std::string& utf8_path2,
                                     const std::string& utf8_path3) {

--- a/src/components/utils/src/file_system_win.cc
+++ b/src/components/utils/src/file_system_win.cc
@@ -215,7 +215,7 @@ bool file_system::FileExists(const std::string& utf8_path) {
 bool file_system::Write(const std::string& utf8_path,
                         const std::vector<uint8_t>& data,
                         std::ios_base::openmode mode) {
-  if (0 == data.size()) {
+  if (data.empty()) {
     return false;
   }
   std::ofstream file(ConvertUTF8ToWString(utf8_path),
@@ -346,7 +346,7 @@ std::vector<std::string> file_system::ListFiles(const std::string& utf8_path) {
 
 bool file_system::WriteBinaryFile(const std::string& utf8_path,
                                   const std::vector<uint8_t>& data) {
-  if (0 == data.size()) {
+  if (data.empty()) {
     return false;
   }
   std::ofstream output(ConvertUTF8ToWString(utf8_path),

--- a/src/components/utils/src/file_system_win.cc
+++ b/src/components/utils/src/file_system_win.cc
@@ -167,15 +167,9 @@ std::string file_system::CreateDirectory(const std::string& utf8_path) {
 }
 
 bool file_system::CreateDirectoryRecursively(const std::string& utf8_path) {
-  size_t pos = 0;
-  bool ret_val = true;
-
-  // We have a lot of hardcoded posix paths.
-  // So lets, just in case, try to replace delimiters
   const std::string delimiter = GetPathDelimiter();
-  utils::ReplaceString(utf8_path, "/", delimiter);
-
-  while (ret_val == true && pos < utf8_path.length()) {
+  size_t pos = utf8_path.find(delimiter, 0);
+  while (pos < utf8_path.length()) {
     pos = utf8_path.find(delimiter, pos + 1);
     if (pos == std::string::npos) {
       pos = utf8_path.length();
@@ -183,11 +177,11 @@ bool file_system::CreateDirectoryRecursively(const std::string& utf8_path) {
     if (!DirectoryExists(utf8_path.substr(0, pos))) {
       if (0 !=
           _wmkdir(ConvertUTF8ToWString(utf8_path.substr(0, pos)).c_str())) {
-        ret_val = false;
+        return false;
       }
     }
   }
-  return ret_val;
+  return true;
 }
 
 bool file_system::IsDirectory(const std::string& utf8_path) {

--- a/src/components/utils/src/file_system_win.cc
+++ b/src/components/utils/src/file_system_win.cc
@@ -198,14 +198,6 @@ bool file_system::CreateDirectoryRecursively(const std::string& utf8_path) {
   return true;
 }
 
-bool file_system::IsDirectory(const std::string& utf8_path) {
-  struct _stat status = {0};
-  if (-1 == _wstat(ConvertUTF8ToWString(utf8_path).c_str(), &status)) {
-    return false;
-  }
-  return S_IFDIR == status.st_mode;
-}
-
 bool file_system::DirectoryExists(const std::string& utf8_path) {
   DWORD attrib = GetFileAttributesW(ConvertUTF8ToWString(utf8_path).c_str());
   return (attrib != INVALID_FILE_ATTRIBUTES &&

--- a/src/components/utils/src/file_system_win.cc
+++ b/src/components/utils/src/file_system_win.cc
@@ -182,7 +182,7 @@ std::string file_system::CreateDirectory(const std::string& utf8_path) {
 
 bool file_system::CreateDirectoryRecursively(const std::string& utf8_path) {
   const std::string delimiter = GetPathDelimiter();
-  size_t pos = utf8_path.find(delimiter, 0);
+  std::size_t pos = utf8_path.find(delimiter, 0);
   while (pos < utf8_path.length()) {
     pos = utf8_path.find(delimiter, pos + 1);
     if (pos == std::string::npos) {
@@ -236,7 +236,7 @@ std::ofstream* file_system::Open(const std::string& utf8_path,
 
 bool file_system::Write(std::ofstream* const file_stream,
                         const uint8_t* data,
-                        size_t data_size) {
+                        std::size_t data_size) {
   if (!file_stream) {
     return false;
   }
@@ -251,7 +251,7 @@ void file_system::Close(std::ofstream* file_stream) {
 }
 
 std::string file_system::CurrentWorkingDirectory() {
-  const size_t filename_max_length = 1024;
+  const std::size_t filename_max_length = 1024;
   char path[filename_max_length];
   _getcwd(path, filename_max_length);
   return std::string(path);
@@ -391,7 +391,7 @@ const std::string file_system::ConvertPathForURL(const std::string& utf8_path) {
     it_sym = reserved_symbols.begin();
     for (; it_sym != it_sym_end; ++it_sym) {
       if (*it_path == *it_sym) {
-        const size_t size = 100;
+        const std::size_t size = 100;
         char percent_value[size];
         _snprintf_s(percent_value, size, "%%%x", *it_path);
         converted_path += percent_value;
@@ -479,8 +479,8 @@ std::string file_system::ConcatPath(const std::string& utf8_path1,
 
 std::string file_system::RetrieveFileNameFromPath(
     const std::string& utf8_path) {
-  size_t slash_pos = utf8_path.find_last_of("/", utf8_path.length());
-  size_t back_slash_pos = utf8_path.find_last_of("\\", utf8_path.length());
+  std::size_t slash_pos = utf8_path.find_last_of("/", utf8_path.length());
+  std::size_t back_slash_pos = utf8_path.find_last_of("\\", utf8_path.length());
   return utf8_path.substr(
       std::max(slash_pos != std::string::npos ? slash_pos + 1 : 0,
                back_slash_pos != std::string::npos ? back_slash_pos + 1 : 0));


### PR DESCRIPTION
Windows allows to create files with paths longer than `MAX_PATH`(260) by using special prefix `\\?\` before file path. But anyway length of each path's component should be no more than 255 characters.
So changes provided within this pull request add `\\?\` prefix before each **absolute** file path passed to WinAPI fucntions. `QFile` is able to create files with long paths 'out of the box'.
