### PR TITLE
Return correct value from getCurrentTime() in Qt

### DIFF
--- a/src/components/utils/src/date_time_qt.cc
+++ b/src/components/utils/src/date_time_qt.cc
@@ -29,28 +29,20 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-
 #include <QDateTime>
 #include <stdint.h>
 
 #include "utils/date_time.h"
 
-namespace {
-const uint64_t kDeltaEpochInMicrosecs = 11644473600000000;
-}  // namespace
-
 namespace date_time {
 
 TimevalStruct DateTime::getCurrentTime() {
-  const qint64 tmpres =
-      QDateTime::currentMSecsSinceEpoch() - kDeltaEpochInMicrosecs;
+  const qint64 tmpres = QDateTime::currentMSecsSinceEpoch();
+
   TimevalStruct tv;
-
-  // Finally change microseconds to seconds and place in the seconds value.
-  // The modulus picks up the microseconds.
-  tv.tv_sec = (long)(tmpres / kMicrosecondsInSecond);
-  tv.tv_usec = (long)(tmpres % kMicrosecondsInSecond);
-
+  tv.tv_sec = static_cast<long>(tmpres / kMillisecondsInSecond);
+  tv.tv_usec = static_cast<long>((tmpres % kMillisecondsInSecond) *
+                                 kMicrosecondsInMillisecond);
   return tv;
 }
 

--- a/src/components/utils/src/date_time_win.cc
+++ b/src/components/utils/src/date_time_win.cc
@@ -62,8 +62,8 @@ TimevalStruct DateTime::getCurrentTime() {
 
   // Finally change microseconds to seconds and place in the seconds value.
   // The modulus picks up the microseconds.
-  tv.tv_sec = (long)(tmpres / 1000000UL);
-  tv.tv_usec = (long)(tmpres % 1000000UL);
+  tv.tv_sec = static_cast<long>(tmpres / kMicrosecondsInSecond);
+  tv.tv_usec = static_cast<long>(tmpres % kMicrosecondsInSecond);
 
   return tv;
 }


### PR DESCRIPTION
`kDeltaEpochInMicrosecs` constant uses in `WIN_NATIVE` version to convert epoch time to appropriate value (number of seconds elapsed since 00:00 hours, Jan 1, 1970 UTC). `QDateTime::currentMSecsSinceEpoch()` returns correct value and shouldn't be converted.
