### PR TITLE
Fix SDL stops with assert in appication_manager

### DIFF
--- a/src/components/application_manager/include/application_manager/state_controller.h
+++ b/src/components/application_manager/include/application_manager/state_controller.h
@@ -295,7 +295,7 @@ class StateController : public event_engine::EventObserver {
     HmiLevelConflictResolver(ApplicationSharedPtr app,
                              HmiStatePtr state,
                              StateController* state_ctrl)
-        : applied_(app), state_(state) {}
+        : applied_(app), state_(state), state_ctrl_(state_ctrl) {}
     void operator()(ApplicationSharedPtr to_resolve);
   };
 


### PR DESCRIPTION
Fix SDL stops with assert in application_manager::StateController::HmiLevelConflictResolver::operator()

Closes-Bug:[SDLWIN-335](https://adc.luxoft.com/jira/browse/SDLWIN-335)
