### PR TITLE
Perform finalization for query within the Reset() body

### DIFF
--- a/src/components/utils/src/sql_qt_wrapper/sql_query.cc
+++ b/src/components/utils/src/sql_qt_wrapper/sql_query.cc
@@ -87,6 +87,8 @@ bool SQLQuery::Next() {
 }
 
 bool SQLQuery::Reset() {
+  // Need too clear query until use it again with new data
+  Finalize();
   return true;
 }
 


### PR DESCRIPTION
The finalization required to clear all data related to previous
query execution. Otherwise the data will not be fatched with Next command

Fix: SDLWIN-333
