### PR TITLE
Correction termination by Ctrl-C for Windows

### DIFF
--- a/src/components/utils/include/utils/signals.h
+++ b/src/components/utils/include/utils/signals.h
@@ -33,18 +33,23 @@
 #ifndef SRC_COMPONENTS_UTILS_INCLUDE_UTILS_SIGNALS_H_
 #define SRC_COMPONENTS_UTILS_INCLUDE_UTILS_SIGNALS_H_
 
-#if defined(__QNXNTO__) || defined(OS_WINDOWS)
+#if defined(__QNXNTO__)
 typedef void (*sighandler_t)(int);
-#else
+#elif defined(POSIX)
 #include <signal.h>
 #endif
 
 namespace utils {
 
+#if defined(OS_WINDOWS)
+bool SubscribeToInterruptSignal(PHANDLER_ROUTINE func);
+bool SubscribeToTerminateSignal(PHANDLER_ROUTINE func);
+bool SubscribeToFaultSignal(PHANDLER_ROUTINE func);
+#else
 bool SubscribeToInterruptSignal(sighandler_t func);
 bool SubscribeToTerminateSignal(sighandler_t func);
 bool SubscribeToFaultSignal(sighandler_t func);
-
+#endif
 }  //  namespace utils
 
 #endif  //  SRC_COMPONENTS_UTILS_INCLUDE_UTILS_SIGNALS_H_

--- a/src/components/utils/src/signals_win.cc
+++ b/src/components/utils/src/signals_win.cc
@@ -31,23 +31,21 @@
  */
 #if defined(OS_WINDOWS)
 
-#include <csignal>
-
 #include "utils/winhdr.h"
 #include "utils/signals.h"
 
 namespace utils {
 
-bool SubscribeToInterruptSignal(sighandler_t func) {
-  return signal(SIGINT, func) != SIG_ERR;
+bool SubscribeToInterruptSignal(PHANDLER_ROUTINE func) {
+  return SetConsoleCtrlHandler(func, TRUE);
 }
 
-bool SubscribeToTerminateSignal(sighandler_t func) {
-  return signal(SIGTERM, func) != SIG_ERR;
+bool SubscribeToTerminateSignal(PHANDLER_ROUTINE func) {
+  return SetConsoleCtrlHandler(func, TRUE);
 }
 
-bool SubscribeToFaultSignal(sighandler_t func) {
-  return signal(SIGSEGV, func) != SIG_ERR;
+bool SubscribeToFaultSignal(PHANDLER_ROUTINE func) {
+  return SetConsoleCtrlHandler(func, TRUE);
 }
 
 }  //  namespace utils


### PR DESCRIPTION
Why do we use `SetConsoleCtrlHandler` instead `signal(SIGINT,..)` : https://msdn.microsoft.com/en-us/library/ms683155(VS.85).aspx and https://msdn.microsoft.com/en-us/library/windows/desktop/ms682541(v=vs.85).aspx
About `signal(SIGINT,..)`: https://msdn.microsoft.com/en-us/library/xdkz3x12(v=vs.120).aspx

Closes-Bug:[SDLWIN-334](https://adc.luxoft.com/jira/browse/SDLWIN-334)
