### PR TITLE
Refactor a bit security manager in order to avoid dead locks

### DIFF
--- a/src/components/security_manager/include/security_manager/crypto_manager_impl.h
+++ b/src/components/security_manager/include/security_manager/crypto_manager_impl.h
@@ -86,12 +86,16 @@ class CryptoManagerImpl : public CryptoManager {
     void PrintCertData(X509* cert, const std::string& cert_owner);
 
    private:
+    X509* GetCertificate() const;
     void PrintCertInfo();
     HandshakeResult CheckCertContext();
     bool ReadHandshakeData(const uint8_t** const out_data,
                            size_t* out_data_size);
     bool WriteHandshakeData(const uint8_t* const in_data, size_t in_data_size);
     HandshakeResult PerformHandshake();
+    HandshakeResult ProcessSuccessHandshake();
+    HandshakeResult ProcessHandshakeError(const int handshake_error);
+    bool CheckInitFinished();
     typedef size_t (*BlockSizeGetter)(size_t);
     void EnsureBufferSizeEnough(size_t size);
     void SetHandshakeError(const int error);

--- a/src/components/security_manager/include/security_manager/crypto_manager_impl.h
+++ b/src/components/security_manager/include/security_manager/crypto_manager_impl.h
@@ -37,17 +37,17 @@
 #include "utils/winhdr.h"
 #endif
 
-#include <stdint.h>
 #include <openssl/bio.h>
-#include <openssl/ssl.h>
 #include <openssl/err.h>
-#include <string>
+#include <openssl/ssl.h>
+#include <stdint.h>
 #include <map>
+#include <string>
 
 #include "security_manager/crypto_manager.h"
 #include "security_manager/ssl_context.h"
-#include "utils/macro.h"
 #include "utils/lock.h"
+#include "utils/macro.h"
 
 #ifdef OS_WINDOWS
 #ifdef X509_NAME

--- a/src/components/security_manager/include/security_manager/crypto_manager_impl.h
+++ b/src/components/security_manager/include/security_manager/crypto_manager_impl.h
@@ -103,7 +103,7 @@ class CryptoManagerImpl : public CryptoManager {
     BIO* bioIn_;
     BIO* bioOut_;
     BIO* bioFilter_;
-    mutable sync_primitives::Lock bio_locker;
+    mutable sync_primitives::Lock ssl_locker_;
     size_t buffer_size_;
     uint8_t* buffer_;
     bool is_handshake_pending_;

--- a/src/components/security_manager/src/ssl_context_impl.cc
+++ b/src/components/security_manager/src/ssl_context_impl.cc
@@ -32,12 +32,12 @@
 #include "security_manager/crypto_manager_impl.h"
 
 #include <assert.h>
-#include <openssl/bio.h>
-#include <openssl/ssl.h>
-#include <openssl/err.h>
 #include <memory.h>
-#include <map>
+#include <openssl/bio.h>
+#include <openssl/err.h>
+#include <openssl/ssl.h>
 #include <algorithm>
+#include <map>
 
 #include "utils/macro.h"
 

--- a/src/components/security_manager/src/ssl_context_impl.cc
+++ b/src/components/security_manager/src/ssl_context_impl.cc
@@ -69,7 +69,7 @@ std::string CryptoManagerImpl::SSLContextImpl::LastError() const {
 }
 
 bool CryptoManagerImpl::SSLContextImpl::IsInitCompleted() const {
-  sync_primitives::AutoLock locker(bio_locker);
+  sync_primitives::AutoLock locker(ssl_locker_);
   return SSL_is_init_finished(connection_);
 }
 
@@ -346,7 +346,7 @@ bool CryptoManagerImpl::SSLContextImpl::Encrypt(const uint8_t* const in_data,
                                                 size_t in_data_size,
                                                 const uint8_t** const out_data,
                                                 size_t* out_data_size) {
-  sync_primitives::AutoLock locker(bio_locker);
+  sync_primitives::AutoLock locker(ssl_locker_);
   if (!SSL_is_init_finished(connection_) || !in_data || !in_data_size) {
     return false;
   }
@@ -372,7 +372,7 @@ bool CryptoManagerImpl::SSLContextImpl::Decrypt(const uint8_t* const in_data,
                                                 size_t in_data_size,
                                                 const uint8_t** const out_data,
                                                 size_t* out_data_size) {
-  sync_primitives::AutoLock locker(bio_locker);
+  sync_primitives::AutoLock locker(ssl_locker_);
   if (!SSL_is_init_finished(connection_)) {
     return false;
   }

--- a/src/components/security_manager/src/ssl_context_impl.cc
+++ b/src/components/security_manager/src/ssl_context_impl.cc
@@ -173,6 +173,7 @@ void CryptoManagerImpl::SSLContextImpl::PrintCertData(
 }
 
 void CryptoManagerImpl::SSLContextImpl::PrintCertInfo() {
+  sync_primitives::AutoLock locker(ssl_locker_);
   PrintCertData(SSL_get_certificate(connection_), "HU's");
 
   STACK_OF(X509)* peer_certs = SSL_get_peer_cert_chain(connection_);
@@ -219,6 +220,7 @@ CryptoManagerImpl::SSLContextImpl::CheckCertContext() {
 bool CryptoManagerImpl::SSLContextImpl::ReadHandshakeData(
     const uint8_t** const out_data, size_t* out_data_size) {
   LOG4CXX_AUTO_TRACE(logger_);
+  sync_primitives::AutoLock locker(ssl_locker_);
   const size_t pend = BIO_ctrl_pending(bioOut_);
   LOG4CXX_DEBUG(logger_, "Available " << pend << " bytes for handshake");
 
@@ -244,6 +246,7 @@ bool CryptoManagerImpl::SSLContextImpl::ReadHandshakeData(
 bool CryptoManagerImpl::SSLContextImpl::WriteHandshakeData(
     const uint8_t* const in_data, size_t in_data_size) {
   LOG4CXX_AUTO_TRACE(logger_);
+  sync_primitives::AutoLock locker(ssl_locker_);
   if (in_data && in_data_size) {
     const int ret = BIO_write(bioIn_, in_data, in_data_size);
     if (ret <= 0) {
@@ -259,49 +262,71 @@ SSLContext::HandshakeResult
 CryptoManagerImpl::SSLContextImpl::PerformHandshake() {
   const int handshake_result = SSL_do_handshake(connection_);
   if (handshake_result == 1) {
-    const HandshakeResult result = CheckCertContext();
-    if (result != Handshake_Result_Success) {
-      ResetConnection();
-      is_handshake_pending_ = false;
-      return result;
-    }
-
-    LOG4CXX_DEBUG(logger_, "SSL handshake successfully finished");
-    // Handshake is successful
-    bioFilter_ = BIO_new(BIO_f_ssl());
-    BIO_set_ssl(bioFilter_, connection_, BIO_NOCLOSE);
-
-    const SSL_CIPHER* cipher = SSL_get_current_cipher(connection_);
-    max_block_size_ = max_block_sizes[SSL_CIPHER_get_name(cipher)];
-    is_handshake_pending_ = false;
-
+    return ProcessSuccessHandshake();
   } else if (handshake_result == 0) {
+    sync_primitives::AutoLock locker(ssl_locker_);
     SSL_clear(connection_);
     is_handshake_pending_ = false;
     return Handshake_Result_Fail;
   } else {
-    const int error = SSL_get_error(connection_, handshake_result);
-    if (error != SSL_ERROR_WANT_READ) {
-      const long error = SSL_get_verify_result(connection_);
-      SetHandshakeError(error);
-      LOG4CXX_WARN(logger_,
-                   "Handshake failed with error "
-                       << " -> "
-                       << SSL_get_error(connection_, error)
-                       << " \""
-                       << LastError()
-                       << '"');
-      ResetConnection();
-      is_handshake_pending_ = false;
-
-      // In case error happened but ssl verification shows OK
-      // method will return AbnormalFail.
-      if (X509_V_OK == error) {
-        return Handshake_Result_AbnormalFail;
-      }
-      return openssl_error_convert_to_internal(error);
-    }
+    return ProcessHandshakeError(handshake_result);
   }
+  return Handshake_Result_Success;
+}
+
+SSLContext::HandshakeResult
+CryptoManagerImpl::SSLContextImpl::ProcessSuccessHandshake() {
+  sync_primitives::AutoLock locker(ssl_locker_);
+  const HandshakeResult result = CheckCertContext();
+  if (result != Handshake_Result_Success) {
+    ResetConnection();
+    is_handshake_pending_ = false;
+    return result;
+  }
+
+  LOG4CXX_DEBUG(logger_, "SSL handshake successfully finished");
+  // Handshake is successful
+  bioFilter_ = BIO_new(BIO_f_ssl());
+  BIO_set_ssl(bioFilter_, connection_, BIO_NOCLOSE);
+
+  const SSL_CIPHER* cipher = SSL_get_current_cipher(connection_);
+  max_block_size_ = max_block_sizes[SSL_CIPHER_get_name(cipher)];
+  is_handshake_pending_ = false;
+
+  return result;
+}
+
+SSLContext::HandshakeResult
+CryptoManagerImpl::SSLContextImpl::ProcessHandshakeError(
+    const int handshake_error) {
+  // Since the LastError function uses lock and this one is public
+  // we need to cache its value before execute code below
+  // in order  to prevent dead lock, since our mutex is not recursive one.
+  const std::string& last_error = LastError();
+
+  sync_primitives::AutoLock locker(ssl_locker_);
+  const int error = SSL_get_error(connection_, handshake_error);
+  if (error != SSL_ERROR_WANT_READ) {
+    const long error = SSL_get_verify_result(connection_);
+    SetHandshakeError(error);
+    LOG4CXX_WARN(logger_,
+                 "Handshake failed with error "
+                     << " -> "
+                     << SSL_get_error(connection_, error)
+                     << " \""
+                     << last_error
+                     << '"');
+    ResetConnection();
+    is_handshake_pending_ = false;
+
+    // In case error happened but ssl verification shows OK
+    // method will return AbnormalFail.
+    if (X509_V_OK == error) {
+      return Handshake_Result_AbnormalFail;
+    }
+    return openssl_error_convert_to_internal(error);
+  }
+
   return Handshake_Result_Success;
 }
 
@@ -316,11 +341,7 @@ SSLContext::HandshakeResult CryptoManagerImpl::SSLContextImpl::DoHandshakeStep(
   *out_data = NULL;
   *out_data_size = 0;
 
-  // TODO(Ezamakhov): add test - hanshake fail -> restart StartHandshake
-  sync_primitives::AutoLock locker(bio_locker);
-  if (SSL_is_init_finished(connection_)) {
-    LOG4CXX_DEBUG(logger_, "SSL initilization is finished");
-    is_handshake_pending_ = false;
+  if (CheckInitFinished()) {
     return Handshake_Result_Success;
   }
 
@@ -340,6 +361,17 @@ SSLContext::HandshakeResult CryptoManagerImpl::SSLContextImpl::DoHandshakeStep(
   }
 
   return res;
+}
+
+bool CryptoManagerImpl::SSLContextImpl::CheckInitFinished() {
+  // TODO(Ezamakhov): add test - hanshake fail -> restart StartHandshake
+  sync_primitives::AutoLock locker(ssl_locker_);
+  if (SSL_is_init_finished(connection_)) {
+    LOG4CXX_DEBUG(logger_, "SSL initilization is finished");
+    is_handshake_pending_ = false;
+    return true;
+  }
+  return false;
 }
 
 bool CryptoManagerImpl::SSLContextImpl::Encrypt(const uint8_t* const in_data,


### PR DESCRIPTION
Since the recursive mutexes have been removed, it is required to avoid
lock the same mutex twice within the same thread.
The commit contains changes which are localize  mutex acquire within
little function scope

Fix: SDLWIN-340
