### PR TITLE
Improve socket abstraction and use it instead of raw sockets where possible

### DIFF
--- a/src/appMain/CMakeLists.txt
+++ b/src/appMain/CMakeLists.txt
@@ -172,6 +172,11 @@ if( NOT CMAKE_BUILD_TYPE )
 endif()
 
 add_executable(${PROJECT} ${HEADERS} ${SOURCES})
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+  target_link_libraries(${PROJECT} ws2_32 ${LIBRARIES})
+endif()
+
 if(QT_PORT)
     if(EXTENDED_MEDIA_MODE)
       find_package(Qt5 REQUIRED Multimedia)

--- a/src/components/include/utils/pimpl.h
+++ b/src/components/include/utils/pimpl.h
@@ -48,6 +48,7 @@ template <typename Impl>
 class Pimpl {
  public:
   Pimpl();
+  Pimpl(Impl* impl);
   Pimpl(Pimpl& rhs);
   ~Pimpl();
 

--- a/src/components/include/utils/pimpl_impl.h
+++ b/src/components/include/utils/pimpl_impl.h
@@ -37,7 +37,11 @@
 
 template <typename Impl>
 utils::Pimpl<Impl>::Pimpl()
-    : impl_(new Impl) {}
+    : impl_(new Impl()) {}
+
+template <typename Impl>
+utils::Pimpl<Impl>::Pimpl(Impl* impl)
+    : impl_(impl) {}
 
 template <typename Impl>
 utils::Pimpl<Impl>::Pimpl(utils::Pimpl<Impl>& rhs) {

--- a/src/components/media_manager/src/socket_streamer_adapter.cc
+++ b/src/components/media_manager/src/socket_streamer_adapter.cc
@@ -29,18 +29,8 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-#if defined(OS_WINDOWS)
-#include "utils/winhdr.h"
-
-#elif defined(OS_POSIX)
-#include <sys/socket.h>
-#include <sys/types.h>
-#include <unistd.h>
-#endif
-
-#include "utils/logger.h"
-#include "utils/socket.h"
 #include "media_manager/socket_streamer_adapter.h"
+#include "utils/logger.h"
 
 namespace media_manager {
 
@@ -72,7 +62,7 @@ bool SocketStreamerAdapter::SocketStreamer::Connect() {
   LOG4CXX_AUTO_TRACE(logger);
 
   const int backlog = 5;
-  if (!server_socket_.Listen(ip_, port_, backlog)) {
+  if (!server_socket_.Listen(utils::HostAddress(ip_), port_, backlog)) {
     LOG4CXX_ERROR(logger, "Unable to listen");
     return false;
   }
@@ -97,24 +87,23 @@ void SocketStreamerAdapter::SocketStreamer::Disconnect() {
 bool SocketStreamerAdapter::SocketStreamer::Send(
     protocol_handler::RawMessagePtr msg) {
   LOG4CXX_AUTO_TRACE(logger);
-  size_t ret;
+  std::size_t written = 0u;
   if (is_first_frame_) {
-    ret = client_socket_.Send(header_.c_str(), header_.size());
-    if (ret != header_.size()) {
+    bool sent = client_socket_.Send(header_.c_str(), header_.size(), written);
+    if (!sent || written != header_.size()) {
       LOG4CXX_ERROR(logger, "Unable to send data to socket");
       return false;
     }
     is_first_frame_ = false;
   }
 
-  ret = client_socket_.Send(reinterpret_cast<const char*>(msg->data()),
-                            msg->data_size());
-  if (-1 == ret) {
+  bool sent = client_socket_.Send(msg->data(), msg->data_size(), written);
+  if (!sent) {
     LOG4CXX_ERROR(logger, "Unable to send data to socket");
     return false;
   }
 
-  if (ret != msg->data_size()) {
+  if (written != msg->data_size()) {
     LOG4CXX_WARN(logger, "Couldn't send all the data to socket");
   }
 

--- a/src/components/resumption/src/last_state.cc
+++ b/src/components/resumption/src/last_state.cc
@@ -67,9 +67,15 @@ void resumption::LastState::LoadFromFileSystem() {
     return;
   }
 
+  if (buffer.empty()) {
+    LOG4CXX_DEBUG(logger_, "Buffer is empty.");
+    return;
+  }
+
   JsonValue::ParseResult parse_result = JsonValue::Parse(buffer);
   if (!parse_result.second) {
-    LOG4CXX_WARN(logger_, "Failed to load last state. Cannot parse json");
+    LOG4CXX_WARN(logger_,
+                 "Failed to load last state. Cannot parse json:\n" << buffer);
     return;
   }
   dictionary_ = parse_result.first;

--- a/src/components/transport_manager/include/transport_manager/tcp/tcp_client_listener.h
+++ b/src/components/transport_manager/include/transport_manager/tcp/tcp_client_listener.h
@@ -36,14 +36,10 @@
 #ifndef SRC_COMPONENTS_TRANSPORT_MANAGER_INCLUDE_TRANSPORT_MANAGER_TCP_TCP_CLIENT_LISTENER_H_
 #define SRC_COMPONENTS_TRANSPORT_MANAGER_INCLUDE_TRANSPORT_MANAGER_TCP_TCP_CLIENT_LISTENER_H_
 
-#if defined(OS_WINDOWS)
-#include "utils/winhdr.h"
-#include <iostream>
-#endif
+#include "utils/socket.h"
 
 #include "utils/threads/thread_delegate.h"
 #include "transport_manager/transport_adapter/client_connection_listener.h"
-class Thread;
 
 namespace transport_manager {
 namespace transport_adapter {
@@ -110,11 +106,8 @@ class TcpClientListener : public ClientConnectionListener {
   const bool enable_keepalive_;
   TransportAdapterController* controller_;
   threads::Thread* thread_;
-#ifdef OS_WINDOWS
-  SOCKET socket_;
-#else
-  int socket_;
-#endif
+
+  utils::TcpServerSocket server_socket_;
 
   bool thread_stop_requested_;
 

--- a/src/components/transport_manager/include/transport_manager/transport_adapter/threaded_socket_connection.h
+++ b/src/components/transport_manager/include/transport_manager/transport_adapter/threaded_socket_connection.h
@@ -51,6 +51,7 @@ typedef long ssize_t;
 #include "protocol/common.h"
 #include "utils/threads/thread_delegate.h"
 #include "utils/lock.h"
+#include "utils/socket.h"
 
 using ::transport_manager::transport_adapter::Connection;
 
@@ -90,11 +91,9 @@ class ThreadedSocketConnection : public Connection {
   TransportAdapter::Error Start();
 
   /**
-   * @brief Set variable that hold socket No.
+   * @brief Set variable that hold socket No. Takes the ownership.
    */
-  void set_socket(int socket) {
-    socket_ = socket;
-  }
+  void SetSocket(utils::TcpSocketConnection& socket_connection);
 
  protected:
   /**
@@ -163,6 +162,8 @@ class ThreadedSocketConnection : public Connection {
   FrameQueue frames_to_send_;
   mutable sync_primitives::Lock frames_to_send_mutex_;
 
+  utils::TcpSocketConnection socket_connection_;
+  // temporal holder for the hative handle.. Will be removed later.
   int socket_;
 
 #if defined(OS_POSIX)

--- a/src/components/transport_manager/src/tcp/tcp_client_listener.cc
+++ b/src/components/transport_manager/src/tcp/tcp_client_listener.cc
@@ -30,34 +30,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-
-#ifdef OS_WINDOWS
-#include "utils/winhdr.h"
-#include <io.h>
-#endif
-#ifndef SHUT_RDWR
-#define SHUT_RDWR SD_BOTH
-#endif
-
 #include "transport_manager/tcp/tcp_client_listener.h"
-#include <memory.h>
-#include <signal.h>
-#include <errno.h>
-#include <sys/types.h>
-#ifdef OS_POSIX
-#include <linux/tcp.h>
-#elif defined(__linux__)
-#include <sys/sysctl.h>
-#include <sys/socket.h>
-#include <arpa/inet.h>
-#include <unistd.h>
-#include <sys/time.h>
-#include <netinet/in.h>
-#include <netinet/tcp.h>
-#include <netinet/tcp_var.h>
-#endif  // __linux__
-
-#include <sstream>
 
 #include "utils/logger.h"
 #include "utils/threads/thread.h"
@@ -77,70 +50,22 @@ TcpClientListener::TcpClientListener(TransportAdapterController* controller,
     , enable_keepalive_(enable_keepalive)
     , controller_(controller)
     , thread_(0)
-    , socket_(-1)
+    , server_socket_()
     , thread_stop_requested_(false) {
   thread_ = threads::CreateThread("TcpClientListener",
                                   new ListeningThreadDelegate(this));
 }
 
-namespace {
-
-int CloseSocket(int socket) {
-#if defined(OS_POSIX)
-  return close(socket);
-#elif defined(OS_WINDOWS)
-  int result = closesocket(socket);
-  return result;
-#else
-#error Unsupported platform
-#endif
-}
-
-int GetErrorCode() {
-#if defined(OS_POSIX)
-  return errno;
-#elif defined(OS_WINDOWS)
-  return WSAGetLastError();
-#else
-#error Unsupported platform
-#endif
-}
-
-}  // namespace
-
 TransportAdapter::Error TcpClientListener::Init() {
   LOG4CXX_AUTO_TRACE(logger_);
   thread_stop_requested_ = false;
 
-  socket_ = socket(AF_INET, SOCK_STREAM, 0);
-  if (-1 == socket_) {
-    LOG4CXX_ERROR(logger_,
-                  "Failed to create socket. Error: " << GetErrorCode());
-    return TransportAdapter::FAIL;
-  }
-
-  sockaddr_in server_address = {0};
-  server_address.sin_family = AF_INET;
-  server_address.sin_port = htons(port_);
-  server_address.sin_addr.s_addr = INADDR_ANY;
-
-  int optval = 1;
-  setsockopt(socket_,
-             SOL_SOCKET,
-             SO_REUSEADDR,
-             reinterpret_cast<char*>(&optval),
-             sizeof(optval));
-
-  if (bind(socket_,
-           reinterpret_cast<sockaddr*>(&server_address),
-           sizeof(server_address)) != 0) {
-    LOG4CXX_ERROR(logger_, "bind() failed. Error: " << GetErrorCode());
-    return TransportAdapter::FAIL;
-  }
-
   const int kBacklog = 128;
-  if (0 != listen(socket_, kBacklog)) {
-    LOG4CXX_ERROR(logger_, "listen() failed. Error: " << GetErrorCode());
+  const utils::HostAddress address(utils::SpecialAddress::Any);
+
+  if (!server_socket_.Listen(address, port_, kBacklog)) {
+    LOG4CXX_ERROR(logger_,
+                  "Failed to listen on " << address.ToString() << ":" << port_);
     return TransportAdapter::FAIL;
   }
   return TransportAdapter::OK;
@@ -148,18 +73,9 @@ TransportAdapter::Error TcpClientListener::Init() {
 
 void TcpClientListener::Terminate() {
   LOG4CXX_AUTO_TRACE(logger_);
-  if (socket_ == -1) {
-    LOG4CXX_WARN(logger_, "Socket has been closed");
-    return;
+  if (!server_socket_.Close()) {
+    LOG4CXX_ERROR(logger_, "Failed to close server socket");
   }
-  if (shutdown(socket_, SHUT_RDWR) != 0) {
-    LOG4CXX_ERROR(logger_,
-                  "Failed to shutdown socket. Error: " << GetErrorCode());
-  }
-  if (CloseSocket(socket_) != 0) {
-    LOG4CXX_ERROR(logger_, "Failed to close socket. Error: " << GetErrorCode());
-  }
-  socket_ = -1;
 }
 
 bool TcpClientListener::IsInitialised() const {
@@ -174,128 +90,44 @@ TcpClientListener::~TcpClientListener() {
   Terminate();
 }
 
-void SetKeepaliveOptions(const int fd) {
-  LOG4CXX_AUTO_TRACE(logger_);
-  LOG4CXX_DEBUG(logger_, "fd: " << fd);
-  int yes = 1;
-  int keepidle = 3;  // 3 seconds to disconnection detecting
-  int keepcnt = 5;
-  int keepintvl = 1;
-#ifdef __linux__
-  int user_timeout = 7000;  // milliseconds
-  setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &yes, sizeof(yes));
-  setsockopt(fd, IPPROTO_TCP, TCP_KEEPIDLE, &keepidle, sizeof(keepidle));
-  setsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT, &keepcnt, sizeof(keepcnt));
-  setsockopt(fd, IPPROTO_TCP, TCP_KEEPINTVL, &keepintvl, sizeof(keepintvl));
-  setsockopt(
-      fd, IPPROTO_TCP, TCP_USER_TIMEOUT, &user_timeout, sizeof(user_timeout));
-#elif defined(OS_WINDOWS)
-  int user_timeout = 7000;  // milliseconds
-  struct tcp_keepalive settings;
-  settings.onoff = 1;
-  settings.keepalivetime = keepidle * 1000;
-  settings.keepaliveinterval = keepintvl * 1000;
-
-  DWORD bytesReturned;
-  WSAOVERLAPPED overlapped;
-  overlapped.hEvent = NULL;
-  WSAIoctl(fd,
-           SIO_KEEPALIVE_VALS,
-           &settings,
-           sizeof(struct tcp_keepalive),
-           NULL,
-           0,
-           &bytesReturned,
-           &overlapped,
-           NULL);
-#elif defined(__QNX__)  // __linux__
-  // TODO(KKolodiy): Out of order!
-  const int kMidLength = 4;
-  int mib[kMidLength];
-
-  mib[0] = CTL_NET;
-  mib[1] = AF_INET;
-  mib[2] = IPPROTO_TCP;
-  mib[3] = TCPCTL_KEEPIDLE;
-  sysctl(mib, kMidLength, NULL, NULL, &keepidle, sizeof(keepidle));
-
-  mib[0] = CTL_NET;
-  mib[1] = AF_INET;
-  mib[2] = IPPROTO_TCP;
-  mib[3] = TCPCTL_KEEPCNT;
-  sysctl(mib, kMidLength, NULL, NULL, &keepcnt, sizeof(keepcnt));
-
-  mib[0] = CTL_NET;
-  mib[1] = AF_INET;
-  mib[2] = IPPROTO_TCP;
-  mib[3] = TCPCTL_KEEPINTVL;
-  sysctl(mib, kMidLength, NULL, NULL, &keepintvl, sizeof(keepintvl));
-
-  struct timeval tval = {0};
-  tval.tv_sec = keepidle;
-  setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &yes, sizeof(yes));
-  setsockopt(fd, IPPROTO_TCP, TCP_KEEPALIVE, &tval, sizeof(tval));
-#endif                  // __QNX__
-}
-
 void TcpClientListener::Loop() {
   LOG4CXX_AUTO_TRACE(logger_);
   while (!thread_stop_requested_) {
-    sockaddr_in client_address;
-#if defined(OS_POSIX)
-    socklen_t client_address_size = sizeof(client_address);
-#elif defined(OS_WINDOWS)
-    int client_address_size = sizeof(client_address);
-#endif
-    const int connection_fd = static_cast<int>(accept(
-        socket_, (struct sockaddr*)&client_address, &client_address_size));
+    // Wait for the new connection
+    utils::TcpSocketConnection client_connection = server_socket_.Accept();
+
     if (thread_stop_requested_) {
       LOG4CXX_DEBUG(logger_, "thread_stop_requested_");
-      CloseSocket(connection_fd);
+      client_connection.Close();
       break;
     }
 
-    if (connection_fd < 0) {
-      LOG4CXX_ERROR(logger_, "accept() failed. Error: " << GetErrorCode());
+    if (!client_connection.IsValid()) {
+      LOG4CXX_ERROR(logger_, "Failed to accept new client connection");
       continue;
     }
 
-#if defined(OS_WINDOWS)
-    // Make windows socket non-block
-    unsigned long socket_mode = 1;
-    if (!ioctlsocket(connection_fd, FIONBIO, &socket_mode) == 0) {
-      LOG4CXX_DEBUG(logger_, "Failed to set socket to non blocking mode");
-      CloseSocket(connection_fd);
-      continue;
-    }
-#endif
-
-    if (AF_INET != client_address.sin_family) {
-      LOG4CXX_DEBUG(logger_, "Address of connected client is invalid");
-      CloseSocket(connection_fd);
-      continue;
-    }
-
-    char device_name[32];
-    strncpy(device_name,
-            inet_ntoa(client_address.sin_addr),
-            sizeof(device_name) / sizeof(device_name[0]));
-    LOG4CXX_INFO(logger_, "Connected client " << device_name);
+    const utils::HostAddress client_address = client_connection.GetAddress();
+    LOG4CXX_INFO(logger_,
+                 "Connected client " << client_address.ToString() << ":"
+                                     << client_connection.GetPort());
 
     if (enable_keepalive_) {
-      SetKeepaliveOptions(connection_fd);
+      client_connection.EnableKeepalive();
     }
 
     TcpDevice* tcp_device =
-        new TcpDevice(client_address.sin_addr.s_addr, device_name);
+        new TcpDevice(client_address, client_address.ToString());
     DeviceSptr device = controller_->AddDevice(tcp_device);
     tcp_device = static_cast<TcpDevice*>(device.get());
     const ApplicationHandle app_handle =
-        tcp_device->AddIncomingApplication(connection_fd);
+        tcp_device->AddApplication(client_connection.GetPort(), true);
 
     TcpSocketConnection* connection(new TcpSocketConnection(
         device->unique_device_id(), app_handle, controller_));
-    connection->set_socket(connection_fd);
+    // Ownership on socket is transfered to connection
+    connection->SetSocket(client_connection);
+
     const TransportAdapter::Error error = connection->Start();
     if (error != TransportAdapter::OK) {
       delete connection;
@@ -307,28 +139,16 @@ void TcpClientListener::StopLoop() {
   LOG4CXX_AUTO_TRACE(logger_);
   thread_stop_requested_ = true;
   // We need to connect to the listening socket to unblock accept() call
-  int byesocket = static_cast<int>(socket(AF_INET, SOCK_STREAM, 0));
-  if (-1 == byesocket) {
+  // "0.0.0.0" is not valid address to connect to.
+  utils::TcpSocketConnection byesocket;
+  utils::HostAddress address(utils::SpecialAddress::LoopBack);
+  if (!byesocket.Connect(address, port_)) {
     LOG4CXX_ERROR(logger_,
-                  "Failed to create bye socket. Error: " << GetErrorCode());
+                  "Bye socket has failed to connect to the server "
+                      << address.ToString()
+                      << ":"
+                      << port_);
   }
-  sockaddr_in server_address = {0};
-  server_address.sin_family = AF_INET;
-  server_address.sin_port = static_cast<USHORT>(htons(port_));
-  // On windows INADDR_ANY is not the correct address for the client side
-  // Here is related discussion
-  // http://stackoverflow.com/questions/22384694/sockets-using-inaddr-any-on-client-side
-  server_address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
-  if (!connect(byesocket,
-               reinterpret_cast<sockaddr*>(&server_address),
-               sizeof(server_address)) == 0) {
-    LOG4CXX_ERROR(logger_,
-                  "Bye socket has failed to connect to the server. Error: "
-                      << GetErrorCode());
-  }
-
-  shutdown(byesocket, (int)SHUT_RDWR);
-  CloseSocket(byesocket);
 }
 
 TransportAdapter::Error TcpClientListener::StartListening() {

--- a/src/components/transport_manager/src/tcp/tcp_client_listener.cc
+++ b/src/components/transport_manager/src/tcp/tcp_client_listener.cc
@@ -33,7 +33,6 @@
 
 #ifdef OS_WINDOWS
 #include "utils/winhdr.h"
-#pragma comment(lib, "Ws2_32.lib")
 #include <io.h>
 #endif
 #ifndef SHUT_RDWR

--- a/src/components/transport_manager/src/tcp/tcp_client_listener.cc
+++ b/src/components/transport_manager/src/tcp/tcp_client_listener.cc
@@ -195,18 +195,6 @@ void SetKeepaliveOptions(const int fd) {
   settings.onoff = 1;
   settings.keepalivetime = keepidle * 1000;
   settings.keepaliveinterval = keepintvl * 1000;
-  // TO DO: check if corerrect setup socket options.
-  // For example posix setup socket options
-  /*  setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, (const char*)&yes, sizeof(yes));
-  **  setsockopt(fd, IPPROTO_TCP, TCP_KEEPIDLE, (const char*)&keepidle,
-  *sizeof(keepidle));
-  **setsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT, (const char*)&keepcnt,
-  *sizeof(keepcnt));
-  **setsockopt(fd, IPPROTO_TCP, TCP_KEEPINTVL, (const char*)&keepintvl,
-  *sizeof(keepintvl));
-  **  setsockopt(fd, IPPROTO_TCP, SO_SNDTIMEO, (const char*)&user_timeout,
-  **	  sizeof(user_timeout));
-  */
 
   DWORD bytesReturned;
   WSAOVERLAPPED overlapped;

--- a/src/components/transport_manager/src/tcp/tcp_device.cc
+++ b/src/components/transport_manager/src/tcp/tcp_device.cc
@@ -33,11 +33,6 @@
 #include "transport_manager/tcp/tcp_device.h"
 #include "utils/logger.h"
 
-#if defined(OS_WINDOWS)
-#include "utils/winhdr.h"
-#pragma comment(lib, "Ws2_32.lib")
-#endif
-
 namespace transport_manager {
 namespace transport_adapter {
 

--- a/src/components/transport_manager/src/tcp/tcp_device.cc
+++ b/src/components/transport_manager/src/tcp/tcp_device.cc
@@ -44,6 +44,7 @@ TcpDevice::TcpDevice(const utils::HostAddress& address, const std::string& name)
     , address_(address)
     , last_handle_(0) {
   LOG4CXX_AUTO_TRACE(logger_);
+  LOG4CXX_DEBUG(logger_, "Created TCPDevice with name " << name);
 }
 
 bool TcpDevice::IsSameAs(const Device* other) const {
@@ -54,7 +55,7 @@ bool TcpDevice::IsSameAs(const Device* other) const {
   if (other_tcp_device->address_ == address_) {
     LOG4CXX_TRACE(
         logger_,
-        "exit with TRUE. Condition: other_tcp_device->in_addr_ == in_addr_");
+        "exit with TRUE. Condition: other_tcp_device->address_ == address_");
     return true;
   } else {
     LOG4CXX_TRACE(logger_, "exit with FALSE");
@@ -64,8 +65,9 @@ bool TcpDevice::IsSameAs(const Device* other) const {
 
 ApplicationList TcpDevice::GetApplicationList() const {
   LOG4CXX_AUTO_TRACE(logger_);
-  sync_primitives::AutoLock locker(applications_mutex_);
   ApplicationList app_list;
+  app_list.reserve(applications_.size());
+  sync_primitives::AutoLock locker(applications_mutex_);
   for (std::map<ApplicationHandle, Application>::const_iterator it =
            applications_.begin();
        it != applications_.end();

--- a/src/components/transport_manager/src/tcp/tcp_socket_connection.cc
+++ b/src/components/transport_manager/src/tcp/tcp_socket_connection.cc
@@ -40,7 +40,6 @@
 #include <unistd.h>
 #elif defined(OS_WINDOWS)
 #include "utils/winhdr.h"
-#pragma comment(lib, "Ws2_32.lib")
 #include <io.h>
 #endif
 

--- a/src/components/transport_manager/src/transport_adapter/threaded_socket_connection.cc
+++ b/src/components/transport_manager/src/transport_adapter/threaded_socket_connection.cc
@@ -108,6 +108,12 @@ void ThreadedSocketConnection::Abort() {
   terminate_flag_ = true;
 }
 
+void ThreadedSocketConnection::SetSocket(
+    utils::TcpSocketConnection& socket_connection) {
+  socket_connection_ = socket_connection;
+  socket_ = socket_connection_.GetNativeHandle();
+}
+
 TransportAdapter::Error ThreadedSocketConnection::Start() {
   LOG4CXX_AUTO_TRACE(logger_);
 #if defined(OS_POSIX)

--- a/src/components/utils/CMakeLists.txt
+++ b/src/components/utils/CMakeLists.txt
@@ -52,6 +52,8 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
                 ${UTILS_INCLUDE_DIR}/utils/system.h
                 ${UTILS_INCLUDE_DIR}/utils/json_utils.h
                 ${UTILS_INCLUDE_DIR}/utils/host_address.h
+                ${UTILS_INCLUDE_DIR}/utils/socket.h
+                ${UTILS_INCLUDE_DIR}/utils/socket_utils.h
                 )
 
       set (src ${UTILS_SRC_DIR}/bitstream.cc
@@ -73,6 +75,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
             ${UTILS_SRC_DIR}/socket_qt.cc
             ${UTILS_SRC_DIR}/json_utils_qt.cc
             ${UTILS_SRC_DIR}/host_address.cc
+            ${UTILS_SRC_DIR}/socket_utils.cc
     )
     # Files copied for the Qt MOC.
     # Because MOC is looking headre nearby with *.cc
@@ -112,6 +115,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
             ${UTILS_SRC_DIR}/socket_win.cc
             ${UTILS_SRC_DIR}/json_utils.cc
             ${UTILS_SRC_DIR}/host_address.cc
+            ${UTILS_SRC_DIR}/socket_utils.cc
     )
   endif()
   if(ENABLE_LOG)
@@ -165,6 +169,7 @@ else()
       ${UTILS_SRC_DIR}/shared_library_posix.cc
       ${UTILS_SRC_DIR}/json_utils.cc
       ${UTILS_SRC_DIR}/host_address.cc
+      ${UTILS_SRC_DIR}/socket_utils.cc
     )
     if(ENABLE_LOG)
       list(APPEND SOURCES

--- a/src/components/utils/CMakeLists.txt
+++ b/src/components/utils/CMakeLists.txt
@@ -51,6 +51,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
                 ${UTILS_INCLUDE_DIR}/utils/string_utils.h
                 ${UTILS_INCLUDE_DIR}/utils/system.h
                 ${UTILS_INCLUDE_DIR}/utils/json_utils.h
+                ${UTILS_INCLUDE_DIR}/utils/host_address.h
                 )
 
       set (src ${UTILS_SRC_DIR}/bitstream.cc
@@ -71,6 +72,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
             ${UTILS_SRC_DIR}/shared_library_qt.cc
             ${UTILS_SRC_DIR}/socket_qt.cc
             ${UTILS_SRC_DIR}/json_utils_qt.cc
+            ${UTILS_SRC_DIR}/host_address.cc
     )
     # Files copied for the Qt MOC.
     # Because MOC is looking headre nearby with *.cc
@@ -109,6 +111,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
             ${UTILS_SRC_DIR}/shared_library_win.cc
             ${UTILS_SRC_DIR}/socket_win.cc
             ${UTILS_SRC_DIR}/json_utils.cc
+            ${UTILS_SRC_DIR}/host_address.cc
     )
   endif()
   if(ENABLE_LOG)
@@ -161,6 +164,7 @@ else()
       ${UTILS_SRC_DIR}/pipe_posix.cc
       ${UTILS_SRC_DIR}/shared_library_posix.cc
       ${UTILS_SRC_DIR}/json_utils.cc
+      ${UTILS_SRC_DIR}/host_address.cc
     )
     if(ENABLE_LOG)
       list(APPEND SOURCES

--- a/src/components/utils/include/utils/host_address.h
+++ b/src/components/utils/include/utils/host_address.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef SRC_COMPONENTS_UTILS_INCLUDE_UTILS_HOST_ADDRESS_H_
+#define SRC_COMPONENTS_UTILS_INCLUDE_UTILS_HOST_ADDRESS_H_
+
+#include <cstdint>
+#include <string>
+
+namespace utils {
+
+namespace SpecialAddress {
+enum Type { Any, LoopBack };
+}  // namespace SpecialAddress
+
+class HostAddress {
+ public:
+  HostAddress();
+
+  explicit HostAddress(const SpecialAddress::Type address);
+
+  explicit HostAddress(const std::string& ip4_address);
+
+  HostAddress(const uint32_t ip4_address, const bool is_host_byte_order);
+
+  bool operator==(const HostAddress& address) const;
+
+  bool operator==(const SpecialAddress::Type address) const;
+
+  inline bool operator!=(const HostAddress& address) const;
+
+  inline bool operator!=(const SpecialAddress::Type address) const;
+
+  uint32_t ToIp4Address(const bool is_host_byte_order) const;
+
+  std::string ToString() const;
+
+ private:
+  // Address in the network byte order
+  uint32_t ip4_;
+};
+
+}  // namespace utils
+
+#endif  // SRC_COMPONENTS_UTILS_INCLUDE_UTILS_HOST_ADDRESS_H_

--- a/src/components/utils/include/utils/socket.h
+++ b/src/components/utils/include/utils/socket.h
@@ -81,9 +81,10 @@ class TcpSocketConnection {
 
   Pimpl<Impl> impl_;
 
-  static const int kKeepAliveTime = 3;  // 3 seconds to disconnection detecting
+  static const int kKeepAliveTimeSec =
+      3;  // 3 seconds to disconnection detecting
 
-  static const int kKeepAliveInterval = 1;
+  static const int kKeepAliveIntervalSec = 1;
 };
 
 class TcpServerSocket {

--- a/src/components/utils/include/utils/socket_utils.h
+++ b/src/components/utils/include/utils/socket_utils.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef SRC_COMPONENTS_UTILS_INCLUDE_UTILS_SOCKET_UTILS_H_
+#define SRC_COMPONENTS_UTILS_INCLUDE_UTILS_SOCKET_UTILS_H_
+
+namespace utils {
+
+void EnableKeepalive(int socket,
+                     int keepalive_time_sec,
+                     int keepalive_Interval_sec);
+
+}  // namespace utils
+
+#endif  // SRC_COMPONENTS_UTILS_INCLUDE_UTILS_SOCKET_UTILS_H_

--- a/src/components/utils/src/host_address.cc
+++ b/src/components/utils/src/host_address.cc
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "utils/host_address.h"
+#include "utils/macro.h"
+
+#if defined(OS_WINDOWS)
+#include "utils/winhdr.h"
+#else
+#include <sys/socket.h>
+#endif
+
+namespace {
+
+uint32_t ToInetAddress(const utils::SpecialAddress::Type address) {
+  switch (address) {
+    case utils::SpecialAddress::Any:
+      return htonl(INADDR_ANY);
+    case utils::SpecialAddress::LoopBack:
+      return htonl(INADDR_LOOPBACK);
+  }
+  DCHECK(!"Unsupported special address");
+  return htonl(INADDR_ANY);
+}
+
+}  // namespace
+
+utils::HostAddress::HostAddress() : ip4_(ToInetAddress(SpecialAddress::Any)) {}
+
+utils::HostAddress::HostAddress(const utils::SpecialAddress::Type address)
+    : ip4_(ToInetAddress(address)) {}
+
+utils::HostAddress::HostAddress(const std::string& ip4_address)
+    : ip4_(inet_addr(ip4_address.c_str())) {}
+
+utils::HostAddress::HostAddress(const uint32_t ip4_address,
+                                const bool is_host_byte_order)
+    : ip4_(is_host_byte_order ? htonl(ip4_address) : ip4_address) {}
+
+uint32_t utils::HostAddress::ToIp4Address(const bool is_host_byte_order) const {
+  return is_host_byte_order ? ntohl(ip4_) : ip4_;
+}
+
+std::string utils::HostAddress::ToString() const {
+  struct in_addr address;
+  address.s_addr = ip4_;
+  return inet_ntoa(address);
+}
+
+bool utils::HostAddress::operator==(const HostAddress& address) const {
+  return ip4_ == address.ip4_;
+}
+
+bool utils::HostAddress::operator==(const SpecialAddress::Type address) const {
+  return ip4_ == ToInetAddress(address);
+}
+
+bool utils::HostAddress::operator!=(const HostAddress& address) const {
+  return !operator==(address);
+}
+
+bool utils::HostAddress::operator!=(const SpecialAddress::Type address) const {
+  return !operator==(address);
+}

--- a/src/components/utils/src/host_address.cc
+++ b/src/components/utils/src/host_address.cc
@@ -46,9 +46,9 @@ uint32_t ToInetAddress(const utils::SpecialAddress::Type address) {
       return htonl(INADDR_ANY);
     case utils::SpecialAddress::LoopBack:
       return htonl(INADDR_LOOPBACK);
+    default:
+      DCHECK_OR_RETURN(!"Unsupported special address", htonl(INADDR_ANY));
   }
-  DCHECK(!"Unsupported special address");
-  return htonl(INADDR_ANY);
 }
 
 }  // namespace

--- a/src/components/utils/src/socket_posix.cc
+++ b/src/components/utils/src/socket_posix.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Ford Motor Company
+ * Copyright (c) 2016, Ford Motor Company
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -35,21 +35,21 @@
 #include <algorithm>
 
 #include "utils/socket.h"
+#include "utils/macro.h"
 
-CREATE_LOGGERPTR_GLOBAL(logger_ptr, "Utils")
+CREATE_LOGGERPTR_GLOBAL(logger_, "Utils")
 
 namespace {
 
 bool CloseSocket(int& socket) {
-  LOG4CXX_AUTO_TRACE(logger_ptr);
-  if (NULL == socket) {
-    LOG4CXX_DEBUG(logger_ptr,
+  LOG4CXX_AUTO_TRACE(logger_);
+  if (0 == socket) {
+    LOG4CXX_DEBUG(logger_,
                   "Socket " << socket << " is not valid. Skip closing.");
     return true;
   }
   if (-1 != close(socket)) {
-    LOG4CXX_WARN(logger_ptr,
-                 "Failed to close socket " << socket << ": " << errno);
+    LOG4CXX_WARN(logger_, "Failed to close socket " << socket << ": " << errno);
     return false;
   }
   socket = NULL;
@@ -66,42 +66,67 @@ class utils::TcpSocketConnection::Impl {
  public:
   Impl();
 
-  explicit Impl(int tcp_socket);
+  explicit Impl(const SOCKET tcp_socket,
+                const HostAddress& address,
+                const uint16_t port);
 
   ~Impl();
 
-  ssize_t Send(const char* buffer, std::size_t size);
+  bool Send(const char* buffer,
+            const std::size_t size,
+            std::size_t& bytes_written);
 
   bool Close();
 
   bool IsValid() const;
 
+  void EnableKeepalive();
+
+  int GetNativeHandle();
+
+  utils::HostAddress GetAddress() const;
+
+  uint16_t GetPort() const;
+
+  bool Connect(const HostAddress& address, const uint16_t port);
+
  private:
   int tcp_socket_;
+
+  HostAddress address_;
+
+  uint16_t port_;
 };
 
-utils::TcpSocketConnection::Impl::Impl() : tcp_socket_(NULL) {}
+utils::TcpSocketConnection::Impl::Impl()
+    : tcp_socket_(0), address_(), port_(0u) {}
 
-utils::TcpSocketConnection::Impl::Impl(int tcp_socket)
-    : tcp_socket_(tcp_socket) {}
+utils::TcpSocketConnection::Impl::Impl(const SOCKET tcp_socket,
+                                       const HostAddress& address,
+                                       const uint16_t port)
+    : tcp_socket_(tcp_socket), address_(address), port_(port) {}
 
 utils::TcpSocketConnection::Impl::~Impl() {
   Close();
 }
 
-ssize_t utils::TcpSocketConnection::Impl::Send(const char* buffer,
-                                               std::size_t size) {
-  LOG4CXX_AUTO_TRACE(logger_ptr);
+bool utils::TcpSocketConnection::Impl::Send(const char* buffer,
+                                            const std::size_t size,
+                                            std::size_t& bytes_written) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  bytes_written = 0u;
   if (!IsValid()) {
-    LOG4CXX_ERROR(logger_ptr, "Failed to send data socket is not valid");
-    return -1;
+    LOG4CXX_ERROR(logger_, "Failed to send data socket is not valid");
+    return false;
   }
   const int flags = MSG_NOSIGNAL;
-  int result = send(tcp_socket_, buffer, size, flags);
-  if (-1 == result) {
-    LOG4CXX_ERROR(logger_ptr, "Failed to send data: " << errno);
+  int written = send(tcp_socket_, buffer, size, flags);
+  if (-1 == written) {
+    LOG4CXX_ERROR(logger_, "Failed to send data: " << errno);
+    return false;
   }
-  return result;
+  bytes_written = static_cast<size_t>(written);
+  return true;
 }
 
 bool utils::TcpSocketConnection::Impl::Close() {
@@ -109,42 +134,125 @@ bool utils::TcpSocketConnection::Impl::Close() {
 }
 
 bool utils::TcpSocketConnection::Impl::IsValid() const {
-  return tcp_socket_ != NULL;
+  return tcp_socket_ != 0;
+}
+
+void utils::TcpSocketConnection::Impl::EnableKeepalive() {
+  int yes = 1;
+  int keepidle = kKeepAliveTime;
+  int keepcnt = 5;
+  int keepintvl = kKeepAliveInterval;
+#ifdef __linux__
+  int user_timeout = 7000;  // milliseconds
+  setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &yes, sizeof(yes));
+  setsockopt(fd, IPPROTO_TCP, TCP_KEEPIDLE, &keepidle, sizeof(keepidle));
+  setsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT, &keepcnt, sizeof(keepcnt));
+  setsockopt(fd, IPPROTO_TCP, TCP_KEEPINTVL, &keepintvl, sizeof(keepintvl));
+  setsockopt(
+      fd, IPPROTO_TCP, TCP_USER_TIMEOUT, &user_timeout, sizeof(user_timeout));
+#elif defined(__QNX__)
+  // TODO(KKolodiy): Out of order!
+  const int kMidLength = 4;
+  int mib[kMidLength];
+
+  mib[0] = CTL_NET;
+  mib[1] = AF_INET;
+  mib[2] = IPPROTO_TCP;
+  mib[3] = TCPCTL_KEEPIDLE;
+  sysctl(mib, kMidLength, NULL, NULL, &keepidle, sizeof(keepidle));
+
+  mib[0] = CTL_NET;
+  mib[1] = AF_INET;
+  mib[2] = IPPROTO_TCP;
+  mib[3] = TCPCTL_KEEPCNT;
+  sysctl(mib, kMidLength, NULL, NULL, &keepcnt, sizeof(keepcnt));
+
+  mib[0] = CTL_NET;
+  mib[1] = AF_INET;
+  mib[2] = IPPROTO_TCP;
+  mib[3] = TCPCTL_KEEPINTVL;
+  sysctl(mib, kMidLength, NULL, NULL, &keepintvl, sizeof(keepintvl));
+
+  struct timeval tval = {0};
+  tval.tv_sec = keepidle;
+  setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &yes, sizeof(yes));
+  setsockopt(fd, IPPROTO_TCP, TCP_KEEPALIVE, &tval, sizeof(tval));
+#else
+#error Unsupported platform
+#endif
+}
+
+int utils::TcpSocketConnection::Impl::GetNativeHandle() {
+  return tcp_socket_;
+}
+
+utils::HostAddress utils::TcpSocketConnection::Impl::GetAddress() const {
+  return address_;
+}
+
+uint16_t utils::TcpSocketConnection::Impl::GetPort() const {
+  return port_;
+}
+
+bool utils::TcpSocketConnection::Impl::Connect(const HostAddress& address,
+                                               const uint16_t port) {
+  if (IsValid()) {
+    LOG4CXX_ERROR(logger_, "Already connected. Closing existing connection.");
+    Close();
+  }
+  int client_socket = socket(AF_INET, SOCK_STREAM, 0);
+  if (-1 == client_socket) {
+    LOG4CXX_ERROR(logger_, "Failed to create client socket. Error: " << errno);
+    return false;
+  }
+  sockaddr_in server_address = {0};
+  server_address.sin_family = AF_INET;
+  server_address.sin_port = htons(port);
+  server_address.sin_addr.s_addr = address.ToIp4Address();
+  if (!connect(client_socket,
+               reinterpret_cast<sockaddr*>(&server_address),
+               sizeof(server_address)) == 0) {
+    LOG4CXX_ERROR(
+        logger_,
+        "Failed to connect to the server " << address.ToString() << ":" << port
+                                           << ". Error: "
+                                           << errno);
+    CloseSocket(client_socket);
+    return false;
+  }
+  tcp_socket_ = client_socket;
+  address_ = address;
+  port_ = port;
+  return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// utils::TcpSocketConnection
 ////////////////////////////////////////////////////////////////////////////////
 
-utils::TcpSocketConnection::TcpSocketConnection() : impl_(new Impl()) {}
+// Ctor&Dtor should be in the cc file
+// to prevent inlining.
+// Otherwise the compiler will try to inline
+// and fail to find ctor of the Pimpl.
+utils::TcpSocketConnection::TcpSocketConnection() {}
 
-utils::TcpSocketConnection::TcpSocketConnection(Impl* impl) : impl_(impl) {
-  DCHECK(impl_);
-}
+utils::TcpSocketConnection::~TcpSocketConnection() {}
 
-utils::TcpSocketConnection::~TcpSocketConnection() {
-  delete impl_;
-}
-
-utils::TcpSocketConnection::TcpSocketConnection(TcpSocketConnection& rhs) {
-  Swap(rhs);
-}
-
+// This must be implemented since default assign operator takes const arg
 utils::TcpSocketConnection& utils::TcpSocketConnection::operator=(
     TcpSocketConnection& rhs) {
-  if (this != &rhs) {
-    Swap(rhs);
-  }
+  impl_ = rhs.impl_;
   return *this;
 }
 
-void utils::TcpSocketConnection::Swap(TcpSocketConnection& rhs) {
-  using std::swap;
-  swap(impl_, rhs.impl_);
+utils::TcpSocketConnection::TcpSocketConnection(Impl* impl) : impl_(impl) {
+  DCHECK(impl);
 }
 
-ssize_t utils::TcpSocketConnection::Send(const char* buffer, std::size_t size) {
-  return impl_->Send(buffer, size);
+bool utils::TcpSocketConnection::Send(const char* buffer,
+                                      const std::size_t size,
+                                      std::size_t& bytes_written) {
+  return impl_->Send(buffer, size, bytes_written);
 }
 
 bool utils::TcpSocketConnection::Close() {
@@ -153,6 +261,27 @@ bool utils::TcpSocketConnection::Close() {
 
 bool utils::TcpSocketConnection::IsValid() const {
   return impl_->IsValid();
+}
+
+void utils::TcpSocketConnection::EnableKeepalive() {
+  impl_->EnableKeepalive();
+}
+
+int utils::TcpSocketConnection::GetNativeHandle() {
+  return impl_->GetNativeHandle();
+}
+
+utils::HostAddress utils::TcpSocketConnection::GetAddress() const {
+  return impl_->GetAddress();
+}
+
+uint16_t utils::TcpSocketConnection::GetPort() const {
+  return impl_->GetPort();
+}
+
+bool utils::TcpSocketConnection::Connect(const HostAddress& address,
+                                         const uint16_t port) {
+  return impl_->Connect(address, port);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -169,11 +298,11 @@ class utils::TcpServerSocket::Impl {
 
   bool Close();
 
-  bool Listen(const std::string& address, int port, int backlog);
+  bool Listen(const HostAddress& address,
+              const uint16_t port,
+              const int backlog);
 
   TcpSocketConnection Accept();
-
-  ssize_t Send(const char* buf, size_t length);
 
  private:
   int server_socket_;
@@ -196,76 +325,103 @@ bool utils::TcpServerSocket::Impl::Close() {
   return CloseSocket(server_socket_);
 }
 
-bool utils::TcpServerSocket::Impl::Listen(const std::string& address,
-                                          int port,
-                                          int backlog) {
-  LOG4CXX_AUTO_TRACE(logger_ptr);
+bool utils::TcpServerSocket::Impl::Listen(const HostAddress& address,
+                                          const uint16_t port,
+                                          const int backlog) {
+  LOG4CXX_AUTO_TRACE(logger_);
   if (IsListening()) {
-    LOG4CXX_ERROR(logger_ptr, "Cannot listen. Already listeneing.");
+    LOG4CXX_ERROR(logger_, "Cannot listen. Already listeneing.");
     return false;
   }
 
-  server_socket_ = socket(AF_INET, SOCK_STREAM, 0);
-  if (-1 == server_socket_) {
-    LOG4CXX_ERROR(logger_ptr, "Failed to create server socket: " << errno);
-    server_socket_ = NULL;
+  int server_socket = socket(AF_INET, SOCK_STREAM, 0);
+  if (-1 == server_socket) {
+    LOG4CXX_ERROR(logger_, "Failed to create server socket: " << errno);
     return false;
   }
 
   char optval = 1;
   if (-1 ==
       setsockopt(
-          server_socket_, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval))) {
-    LOG4CXX_ERROR(logger_ptr, "Unable to set sockopt: " << errno);
-    server_socket_ = NULL;
+          server_socket, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval))) {
+    LOG4CXX_ERROR(logger_, "Unable to set sockopt: " << errno);
     return false;
   }
 
   struct sockaddr_in server_address = {0};
-  server_address.sin_addr.s_addr = inet_addr(address.c_str());
+  server_address.sin_addr.s_addr = address.ToIp4Address();
   server_address.sin_family = AF_INET;
   server_address.sin_port = htons(port);
 
-  if (-1 == bind(server_socket_,
+  if (-1 == bind(server_socket,
                  reinterpret_cast<struct sockaddr*>(&server_address),
                  sizeof(server_address))) {
-    LOG4CXX_ERROR(logger_ptr, "Unable to bind: " << errno);
-    server_socket_ = NULL;
+    LOG4CXX_ERROR(logger_, "Unable to bind: " << errno);
     return false;
   }
 
-  if (-1 == listen(server_socket_, backlog)) {
-    LOG4CXX_ERROR(logger_ptr, "Unable to listen: " << errno);
-    server_socket_ = NULL;
+  LOG4CXX_DEBUG(logger_,
+                "Start listening on " << address.ToString() << ":" << port);
+
+  if (-1 == listen(server_socket, backlog)) {
+    LOG4CXX_ERROR(logger_, "Unable to listen: " << errno);
+    LOG4CXX_WARN(logger_,
+                 "Failed to listen on " << address.ToString() << ":" << port
+                                        << ". Error: "
+                                        << errno);
     return false;
   }
 
+  server_socket_ = server_socket;
   is_listening_ = true;
   return true;
 }
 
 utils::TcpSocketConnection utils::TcpServerSocket::Impl::Accept() {
-  LOG4CXX_AUTO_TRACE(logger_ptr);
+  LOG4CXX_AUTO_TRACE(logger_);
 
-  struct sockaddr client_addr = {0};
-  int client_addr_length = sizeof(client_addr);
-  int client_socket = accept(server_socket_, &client_addr, &client_addr_length);
+  struct sockaddr_in client_address = {0};
+  int client_address_length = sizeof(client_address);
+  int client_socket = accept(server_socket_,
+                             reinterpret_cast<sockaddr*>(&client_address),
+                             &client_address_length);
   if (-1 == client_socket) {
-    LOG4CXX_ERROR(logger_ptr, "Failed to accept client socket: " << errno);
+    LOG4CXX_ERROR(logger_, "Failed to accept client socket: " << errno);
     return utils::TcpSocketConnection();
   }
-  return TcpSocketConnection(new TcpSocketConnection::Impl(client_socket));
+  if (AF_INET != client_address.sin_family) {
+    LOG4CXX_DEBUG(logger_,
+                  "Address of the connected client is invalid. Not AF_INET.");
+    CloseSocket(client_socket);
+    return utils::TcpSocketConnection();
+  }
+  const HostAddress accepted_client_address(inet_ntoa(client_address.sin_addr));
+  LOG4CXX_DEBUG(logger_,
+                "Accepted new client connection "
+                    << accepted_client_address.ToString()
+                    << ":"
+                    << client_address.sin_port);
+  return TcpSocketConnection(new TcpSocketConnection::Impl(
+      client_socket, accepted_client_address, client_address.sin_port));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// utils::TcpServerSocket
 ////////////////////////////////////////////////////////////////////////////////
 
-utils::TcpServerSocket::TcpServerSocket()
-    : impl_(new TcpServerSocket::Impl()) {}
+// Ctor&Dtor should be in the cc file
+// to prevent inlining.
+// Otherwise the compiler will try to inline
+// and fail to find ctor of the Pimpl.
+utils::TcpServerSocket::TcpServerSocket() {}
 
-utils::TcpServerSocket::~TcpServerSocket() {
-  delete impl_;
+utils::TcpServerSocket::~TcpServerSocket() {}
+
+// This must be implemented since default assign operator takes const arg
+utils::TcpServerSocket& utils::TcpServerSocket::operator=(
+    TcpServerSocket& rhs) {
+  impl_ = rhs.impl_;
+  return *this;
 }
 
 bool utils::TcpServerSocket::IsListening() const {
@@ -276,9 +432,9 @@ bool utils::TcpServerSocket::Close() {
   return impl_->Close();
 }
 
-bool utils::TcpServerSocket::Listen(const std::string& address,
-                                    int port,
-                                    int backlog) {
+bool utils::TcpServerSocket::Listen(const HostAddress& address,
+                                    const uint16_t port,
+                                    const int backlog) {
   return impl_->Listen(address, port, backlog);
 }
 

--- a/src/components/utils/src/socket_qt.cc
+++ b/src/components/utils/src/socket_qt.cc
@@ -35,6 +35,7 @@
 
 #include "utils/macro.h"
 #include "utils/pimpl_impl.h"
+#include "utils/socket_utils.h"
 
 CREATE_LOGGERPTR_GLOBAL(logger_, "Utils")
 
@@ -135,7 +136,8 @@ bool utils::TcpSocketConnection::Impl::IsValid() const {
 }
 
 void utils::TcpSocketConnection::Impl::EnableKeepalive() {
-  tcp_socket_->setSocketOption(QAbstractSocket::KeepAliveOption, 1);
+  utils::EnableKeepalive(
+      GetNativeHandle(), kKeepAliveTimeSec, kKeepAliveIntervalSec);
 }
 
 int utils::TcpSocketConnection::Impl::GetNativeHandle() {

--- a/src/components/utils/src/socket_qt.cc
+++ b/src/components/utils/src/socket_qt.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Ford Motor Company
+ * Copyright (c) 2016, Ford Motor Company
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -31,11 +31,24 @@
  */
 #include "utils/socket.h"
 
-#include <algorithm>
-
 #include <QtNetwork>
 
-CREATE_LOGGERPTR_GLOBAL(logger_ptr, "Utils")
+#include "utils/macro.h"
+#include "utils/pimpl_impl.h"
+
+CREATE_LOGGERPTR_GLOBAL(logger_, "Utils")
+
+namespace {
+
+inline QHostAddress FromHostAddress(const utils::HostAddress& address) {
+  return QHostAddress(address.ToIp4Address(true));
+}
+
+inline utils::HostAddress ToHostAddress(const QHostAddress& address) {
+  return utils::HostAddress(address.toIPv4Address(), true);
+}
+
+}  // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
 /// utils::TcpSocketConnection::Impl
@@ -49,11 +62,23 @@ class utils::TcpSocketConnection::Impl {
 
   ~Impl();
 
-  ssize_t Send(const char* buffer, std::size_t size);
+  bool Send(const char* buffer,
+            const std::size_t size,
+            std::size_t& bytes_written);
 
   bool Close();
 
   bool IsValid() const;
+
+  void EnableKeepalive();
+
+  int GetNativeHandle();
+
+  utils::HostAddress GetAddress() const;
+
+  uint16_t GetPort() const;
+
+  bool Connect(const HostAddress& address, const uint16_t port);
 
  private:
   QTcpSocket* tcp_socket_;
@@ -68,31 +93,35 @@ utils::TcpSocketConnection::Impl::~Impl() {
   Close();
 }
 
-ssize_t utils::TcpSocketConnection::Impl::Send(const char* buffer,
-                                               std::size_t size) {
-  LOG4CXX_AUTO_TRACE(logger_ptr);
+bool utils::TcpSocketConnection::Impl::Send(const char* buffer,
+                                            const std::size_t size,
+                                            std::size_t& bytes_written) {
+  bytes_written = 0;
+  LOG4CXX_AUTO_TRACE(logger_);
   if (!IsValid()) {
-    LOG4CXX_WARN(logger_ptr, "Cannot send. Socket is not valid.");
-    return -1;
+    LOG4CXX_WARN(logger_, "Cannot send. Socket is not valid.");
+    return false;
   }
 
   QByteArray data(buffer, size);
-  ssize_t result = tcp_socket_->write(data);
-  if (result != -1) {
+  qint64 written = tcp_socket_->write(data);
+  if (written != -1) {
     tcp_socket_->flush();
     tcp_socket_->waitForBytesWritten();
   } else {
     LOG4CXX_WARN(
-        logger_ptr,
+        logger_,
         "Failed to send: " << tcp_socket_->errorString().toStdString());
+    return false;
   }
-  return result;
+  bytes_written = static_cast<std::size_t>(written);
+  return true;
 }
 
 bool utils::TcpSocketConnection::Impl::Close() {
-  LOG4CXX_AUTO_TRACE(logger_ptr);
+  LOG4CXX_AUTO_TRACE(logger_);
   if (!IsValid()) {
-    LOG4CXX_DEBUG(logger_ptr, "Not valid. Exit Close");
+    LOG4CXX_DEBUG(logger_, "Not valid. Exit Close");
     return true;
   }
   tcp_socket_->close();
@@ -105,48 +134,98 @@ bool utils::TcpSocketConnection::Impl::IsValid() const {
   return tcp_socket_ != NULL;
 }
 
+void utils::TcpSocketConnection::Impl::EnableKeepalive() {
+  tcp_socket_->setSocketOption(QAbstractSocket::KeepAliveOption, 1);
+}
+
+int utils::TcpSocketConnection::Impl::GetNativeHandle() {
+  if (!IsValid()) {
+    return -1;
+  }
+  return tcp_socket_->socketDescriptor();
+}
+
+utils::HostAddress utils::TcpSocketConnection::Impl::GetAddress() const {
+  if (!IsValid()) {
+    return HostAddress(SpecialAddress::Any);
+  }
+  return ToHostAddress(tcp_socket_->peerAddress());
+}
+
+uint16_t utils::TcpSocketConnection::Impl::GetPort() const {
+  if (!IsValid()) {
+    return 0u;
+  }
+  return tcp_socket_->peerPort();
+}
+
+bool utils::TcpSocketConnection::Impl::Connect(const HostAddress& address,
+                                               const uint16_t port) {
+  if (IsValid()) {
+    Close();
+  }
+  tcp_socket_ = new QTcpSocket();
+  tcp_socket_->connectToHost(FromHostAddress(address), port);
+  return tcp_socket_->waitForConnected();
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 /// utils::TcpSocketConnection
 ////////////////////////////////////////////////////////////////////////////////
 
-utils::TcpSocketConnection::TcpSocketConnection() : impl_(new Impl()) {}
+// Ctor&Dtor should be in the cc file
+// to prevent inlining.
+// Otherwise the compiler will try to inline
+// and fail to find ctor of the Pimpl.
+utils::TcpSocketConnection::TcpSocketConnection() {}
 
-utils::TcpSocketConnection::TcpSocketConnection(Impl* impl) : impl_(impl) {
-  DCHECK(impl_);
-}
+utils::TcpSocketConnection::~TcpSocketConnection() {}
 
-utils::TcpSocketConnection::~TcpSocketConnection() {
-  delete impl_;
-}
-
-utils::TcpSocketConnection::TcpSocketConnection(TcpSocketConnection& rhs) {
-  Swap(rhs);
-}
-
+// This must be implemented since default assign operator takes const arg
 utils::TcpSocketConnection& utils::TcpSocketConnection::operator=(
     TcpSocketConnection& rhs) {
-  if (this != &rhs) {
-    Swap(rhs);
-  }
+  impl_ = rhs.impl_;
   return *this;
 }
 
-void utils::TcpSocketConnection::Swap(TcpSocketConnection& rhs) {
-  using std::swap;
-  swap(impl_, rhs.impl_);
+utils::TcpSocketConnection::TcpSocketConnection(Impl* impl) : impl_(impl) {
+  DCHECK(impl);
 }
 
-ssize_t utils::TcpSocketConnection::Send(const char* buffer, std::size_t size) {
-  return impl_->Send(buffer, size);
+bool utils::TcpSocketConnection::Send(const char* buffer,
+                                      std::size_t size,
+                                      std::size_t& bytes_written) {
+  return impl_->Send(buffer, size, bytes_written);
 }
 
 bool utils::TcpSocketConnection::Close() {
-  LOG4CXX_AUTO_TRACE(logger_ptr);
+  LOG4CXX_AUTO_TRACE(logger_);
   return impl_->Close();
 }
 
 bool utils::TcpSocketConnection::IsValid() const {
   return impl_->IsValid();
+}
+
+void utils::TcpSocketConnection::EnableKeepalive() {
+  impl_->EnableKeepalive();
+}
+
+int utils::TcpSocketConnection::GetNativeHandle() {
+  return impl_->GetNativeHandle();
+}
+
+utils::HostAddress utils::TcpSocketConnection::GetAddress() const {
+  return impl_->GetAddress();
+}
+
+uint16_t utils::TcpSocketConnection::GetPort() const {
+  return impl_->GetPort();
+}
+
+bool utils::TcpSocketConnection::Connect(const HostAddress& address,
+                                         const uint16_t port) {
+  return impl_->Connect(address, port);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -163,7 +242,9 @@ class utils::TcpServerSocket::Impl {
 
   bool Close();
 
-  bool Listen(const std::string& address, int port, int backlog);
+  bool Listen(const HostAddress& address,
+              const uint16_t port,
+              const int backlog);
 
   TcpSocketConnection Accept();
 
@@ -174,7 +255,7 @@ class utils::TcpServerSocket::Impl {
 utils::TcpServerSocket::Impl::Impl() : server_socket_(NULL) {}
 
 utils::TcpServerSocket::Impl::~Impl() {
-  LOG4CXX_AUTO_TRACE(logger_ptr);
+  LOG4CXX_AUTO_TRACE(logger_);
   Close();
   delete server_socket_;
 }
@@ -190,12 +271,15 @@ bool utils::TcpServerSocket::Impl::Close() {
   return true;
 }
 
-bool utils::TcpServerSocket::Impl::Listen(const std::string& address,
-                                          int port,
-                                          int backlog) {
-  LOG4CXX_AUTO_TRACE(logger_ptr);
+bool utils::TcpServerSocket::Impl::Listen(const HostAddress& address,
+                                          const uint16_t port,
+                                          const int backlog) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  LOG4CXX_DEBUG(logger_,
+                "Start listening on " << address.ToString() << ":" << port);
+
   if (server_socket_) {
-    LOG4CXX_WARN(logger_ptr, "Cannot listen. server_socket_ is null");
+    LOG4CXX_WARN(logger_, "Cannot listen. server_socket_ is null");
     return false;
   }
 
@@ -203,24 +287,27 @@ bool utils::TcpServerSocket::Impl::Listen(const std::string& address,
 
   server_socket_->setMaxPendingConnections(backlog);
 
-  LOG4CXX_DEBUG(logger_ptr, "Start listening on " << address << ":" << port);
+  LOG4CXX_DEBUG(logger_,
+                "Start listening on " << address.ToString() << ":" << port);
 
-  if (!server_socket_->listen(QHostAddress(address.c_str()), port)) {
+  if (!server_socket_->listen(FromHostAddress(address), port)) {
     LOG4CXX_WARN(
-        logger_ptr,
-        "Failed to listen on " << address << ":" << port << ". Error: "
+        logger_,
+        "Failed to listen on " << address.ToString() << ":" << port
+                               << ". Error: "
                                << server_socket_->errorString().toStdString());
     return false;
   }
 
+  LOG4CXX_DEBUG(logger_, "Listening on " << address.ToString() << ":" << port);
   return true;
 }
 
 utils::TcpSocketConnection utils::TcpServerSocket::Impl::Accept() {
-  LOG4CXX_AUTO_TRACE(logger_ptr);
+  LOG4CXX_AUTO_TRACE(logger_);
   bool waited = server_socket_->waitForNewConnection(-1);
   if (!waited) {
-    LOG4CXX_WARN(logger_ptr,
+    LOG4CXX_WARN(logger_,
                  "Failed to wait for the new connection: "
                      << server_socket_->errorString().toStdString());
     return utils::TcpSocketConnection();
@@ -228,11 +315,16 @@ utils::TcpSocketConnection utils::TcpServerSocket::Impl::Accept() {
 
   QTcpSocket* client_connection = server_socket_->nextPendingConnection();
   if (!client_connection) {
-    LOG4CXX_WARN(logger_ptr,
+    LOG4CXX_WARN(logger_,
                  "Failed to get new connection: "
                      << server_socket_->errorString().toStdString());
     return utils::TcpSocketConnection();
   }
+  LOG4CXX_DEBUG(logger_,
+                "Accepted new client connection "
+                    << client_connection->peerAddress().toString().toStdString()
+                    << ":"
+                    << client_connection->peerPort());
   return TcpSocketConnection(new TcpSocketConnection::Impl(client_connection));
 }
 
@@ -240,11 +332,19 @@ utils::TcpSocketConnection utils::TcpServerSocket::Impl::Accept() {
 /// utils::TcpServerSocket
 ////////////////////////////////////////////////////////////////////////////////
 
-utils::TcpServerSocket::TcpServerSocket()
-    : impl_(new TcpServerSocket::Impl()) {}
+// Ctor&Dtor should be in the cc file
+// to prevent inlining.
+// Otherwise the compiler will try to inline
+// and fail to find ctor of the Pimpl.
+utils::TcpServerSocket::TcpServerSocket() {}
 
-utils::TcpServerSocket::~TcpServerSocket() {
-  delete impl_;
+utils::TcpServerSocket::~TcpServerSocket() {}
+
+// This must be implemented since default assign operator takes const arg
+utils::TcpServerSocket& utils::TcpServerSocket::operator=(
+    TcpServerSocket& rhs) {
+  impl_ = rhs.impl_;
+  return *this;
 }
 
 bool utils::TcpServerSocket::IsListening() const {
@@ -255,9 +355,9 @@ bool utils::TcpServerSocket::Close() {
   return impl_->Close();
 }
 
-bool utils::TcpServerSocket::Listen(const std::string& address,
-                                    int port,
-                                    int backlog) {
+bool utils::TcpServerSocket::Listen(const HostAddress& address,
+                                    const uint16_t port,
+                                    const int backlog) {
   return impl_->Listen(address, port, backlog);
 }
 

--- a/src/components/utils/src/socket_utils.cc
+++ b/src/components/utils/src/socket_utils.cc
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "utils/socket_utils.h"
+
+#if defined(OS_POSIX)
+#include <sys/socket.h>
+#include <sys/types.h>
+#elif defined(OS_WINDOWS)
+#include "utils/winhdr.h"
+#endif
+
+void utils::EnableKeepalive(int socket,
+                            int keepalive_time_sec,
+                            int keepalive_Interval_sec) {
+#ifdef __linux__
+  int yes = 1;
+  int keepcnt = 5;
+  int user_timeout = 7000;  // milliseconds
+  setsockopt(socket, SOL_SOCKET, SO_KEEPALIVE, &yes, sizeof(yes));
+  setsockopt(socket,
+             IPPROTO_TCP,
+             TCP_KEEPIDLE,
+             &keepalive_time_sec,
+             sizeof(keepalive_time_sec));
+  setsockopt(socket, IPPROTO_TCP, TCP_KEEPCNT, &keepcnt, sizeof(keepcnt));
+  setsockopt(socket,
+             IPPROTO_TCP,
+             TCP_KEEPINTVL,
+             &keepalive_Interval_sec,
+             sizeof(keepalive_Interval_sec));
+  setsockopt(socket,
+             IPPROTO_TCP,
+             TCP_USER_TIMEOUT,
+             &user_timeout,
+             sizeof(user_timeout));
+#elif defined(OS_WINDOWS)
+  struct tcp_keepalive settings;
+  settings.onoff = 1;
+  settings.keepalivetime = keepalive_time_sec * 1000;
+  settings.keepaliveinterval = keepalive_Interval_sec * 1000;
+
+  DWORD bytesReturned;
+  WSAOVERLAPPED overlapped;
+  overlapped.hEvent = NULL;
+  WSAIoctl(socket,
+           SIO_KEEPALIVE_VALS,
+           &settings,
+           sizeof(struct tcp_keepalive),
+           NULL,
+           0,
+           &bytesReturned,
+           &overlapped,
+           NULL);
+#elif defined(__QNX__)  // __linux__
+  // TODO(KKolodiy): Out of order!
+  int yes = 1;
+  int keepcnt = 5;
+  const int kMidLength = 4;
+  int mib[kMidLength];
+
+  mib[0] = CTL_NET;
+  mib[1] = AF_INET;
+  mib[2] = IPPROTO_TCP;
+  mib[3] = TCPCTL_KEEPIDLE;
+  sysctl(mib,
+         kMidLength,
+         NULL,
+         NULL,
+         &keepalive_time_sec,
+         sizeof(keepalive_time_sec));
+
+  mib[0] = CTL_NET;
+  mib[1] = AF_INET;
+  mib[2] = IPPROTO_TCP;
+  mib[3] = TCPCTL_KEEPCNT;
+  sysctl(mib, kMidLength, NULL, NULL, &keepcnt, sizeof(keepcnt));
+
+  mib[0] = CTL_NET;
+  mib[1] = AF_INET;
+  mib[2] = IPPROTO_TCP;
+  mib[3] = TCPCTL_KEEPINTVL;
+  sysctl(mib,
+         kMidLength,
+         NULL,
+         NULL,
+         &keepalive_Interval_sec,
+         sizeof(keepalive_Interval_sec));
+
+  struct timeval tval = {0};
+  tval.tv_sec = keepalive_time_sec;
+  setsockopt(socket, SOL_SOCKET, SO_KEEPALIVE, &yes, sizeof(yes));
+  setsockopt(socket, IPPROTO_TCP, TCP_KEEPALIVE, &tval, sizeof(tval));
+#endif                  // __QNX__
+}

--- a/src/components/utils/src/socket_win.cc
+++ b/src/components/utils/src/socket_win.cc
@@ -33,6 +33,7 @@
 #include "utils/winhdr.h"
 #include "utils/macro.h"
 #include "utils/pimpl_impl.h"
+#include "utils/socket_utils.h"
 
 CREATE_LOGGERPTR_GLOBAL(logger_, "Utils")
 
@@ -140,23 +141,8 @@ bool utils::TcpSocketConnection::Impl::IsValid() const {
 }
 
 void utils::TcpSocketConnection::Impl::EnableKeepalive() {
-  struct tcp_keepalive settings;
-  settings.onoff = 1;
-  settings.keepalivetime = kKeepAliveTime * 1000;
-  settings.keepaliveinterval = kKeepAliveInterval * 1000;
-
-  DWORD bytesReturned;
-  WSAOVERLAPPED overlapped;
-  overlapped.hEvent = NULL;
-  WSAIoctl(tcp_socket_,
-           SIO_KEEPALIVE_VALS,
-           &settings,
-           sizeof(struct tcp_keepalive),
-           NULL,
-           0,
-           &bytesReturned,
-           &overlapped,
-           NULL);
+  utils::EnableKeepalive(
+      GetNativeHandle(), kKeepAliveTimeSec, kKeepAliveIntervalSec);
 }
 
 int utils::TcpSocketConnection::Impl::GetNativeHandle() {


### PR DESCRIPTION
Related to the [SDLWIN-312](https://adc.luxoft.com/jira/browse/SDLWIN-312)

Not all socket use cases  we covered. Left read\write events(threaded_socket_connection.cc). In win native this functionality is already present in the code. But used raw sockets. For the Qt this functionality is missing(used win native approach).

Also this PR contains some refactoring of the TCPDevice. Was required to eliminate redundant usage of the raw sockets.
