### PR TITLE
Add proper handling for certificates due date

### DIFF
--- a/src/components/include/security_manager/crypto_manager.h
+++ b/src/components/include/security_manager/crypto_manager.h
@@ -93,7 +93,7 @@ class CryptoManager : public policy::PolicyHandlerObserver {
   virtual void ReleaseSSLContext(SSLContext* context) = 0;
   virtual std::string LastError() const = 0;
 
-  virtual bool IsCertificateUpdateRequired() const = 0;
+  virtual bool IsCertificateUpdateRequired(struct tm cert_due_date) const = 0;
   virtual ~CryptoManager() {}
 };
 

--- a/src/components/include/security_manager/ssl_context.h
+++ b/src/components/include/security_manager/ssl_context.h
@@ -33,10 +33,10 @@
 #ifndef SRC_COMPONENTS_INCLUDE_SECURITY_MANAGER_SSL_CONTEXT_H_
 #define SRC_COMPONENTS_INCLUDE_SECURITY_MANAGER_SSL_CONTEXT_H_
 
-#include <cstddef>  // for size_t typedef
-#include <string>
 #include <ctype.h>
 #include <algorithm>
+#include <cstddef>  // for size_t typedef
+#include <string>
 
 // TODO(EZamakhov): update brief info
 /**
@@ -112,6 +112,7 @@ class SSLContext {
                        size_t* out_data_size) = 0;
   virtual bool IsInitCompleted() const = 0;
   virtual bool IsHandshakePending() const = 0;
+  virtual bool GetCertifcateDueDate(struct tm& due_date) const = 0;
   virtual size_t get_max_block_size(size_t mtu) const = 0;
   virtual std::string LastError() const = 0;
 

--- a/src/components/security_manager/include/security_manager/crypto_manager_impl.h
+++ b/src/components/security_manager/include/security_manager/crypto_manager_impl.h
@@ -37,17 +37,17 @@
 #include "utils/winhdr.h"
 #endif
 
-#include <stdint.h>
 #include <openssl/bio.h>
-#include <openssl/ssl.h>
 #include <openssl/err.h>
-#include <string>
+#include <openssl/ssl.h>
+#include <stdint.h>
 #include <map>
+#include <string>
 
 #include "security_manager/crypto_manager.h"
 #include "security_manager/ssl_context.h"
-#include "utils/macro.h"
 #include "utils/lock.h"
+#include "utils/macro.h"
 
 #ifdef OS_WINDOWS
 #ifdef X509_NAME
@@ -77,6 +77,7 @@ class CryptoManagerImpl : public CryptoManager {
                  size_t* out_data_size) OVERRIDE;
     bool IsInitCompleted() const OVERRIDE;
     bool IsHandshakePending() const OVERRIDE;
+    virtual bool GetCertifcateDueDate(struct tm& due_date) const OVERRIDE;
     size_t get_max_block_size(size_t mtu) const OVERRIDE;
     std::string LastError() const OVERRIDE;
     void ResetConnection() OVERRIDE;
@@ -98,6 +99,9 @@ class CryptoManagerImpl : public CryptoManager {
     HandshakeResult openssl_error_convert_to_internal(const long error);
 
     std::string GetTextBy(X509_NAME* name, int object) const;
+
+    int pull_number_from_buf(char* buf, int* idx) const;
+    void asn1_time_to_tm(ASN1_TIME* time, struct tm& cert_time) const;
 
     SSL* connection_;
     BIO* bioIn_;
@@ -131,16 +135,12 @@ class CryptoManagerImpl : public CryptoManager {
   SSLContext* CreateSSLContext() OVERRIDE;
   void ReleaseSSLContext(SSLContext* context) OVERRIDE;
   std::string LastError() const OVERRIDE;
-  virtual bool IsCertificateUpdateRequired() const OVERRIDE;
+  virtual bool IsCertificateUpdateRequired(struct tm cert_time) const OVERRIDE;
 
  private:
   bool set_certificate(const std::string& cert_data);
 
-  int pull_number_from_buf(char* buf, int* idx);
-  void asn1_time_to_tm(ASN1_TIME* time);
-
   SSL_CTX* context_;
-  mutable struct tm expiration_time_;
   Mode mode_;
   static uint32_t instance_count_;
   static sync_primitives::Lock instance_lock_;

--- a/src/components/security_manager/src/security_manager_impl.cc
+++ b/src/components/security_manager/src/security_manager_impl.cc
@@ -31,11 +31,11 @@
  */
 
 #include "security_manager/security_manager_impl.h"
-#include "security_manager/crypto_manager_impl.h"
 #include "protocol_handler/protocol_packet.h"
-#include "utils/logger.h"
+#include "security_manager/crypto_manager_impl.h"
 #include "utils/byte_order.h"
 #include "utils/json_utils.h"
+#include "utils/logger.h"
 
 namespace security_manager {
 
@@ -188,8 +188,11 @@ void SecurityManagerImpl::StartHandshake(uint32_t connection_key) {
     return;
   }
 
-  if (crypto_manager_->IsCertificateUpdateRequired()) {
-    NotifyOnCertififcateUpdateRequired();
+  struct tm cert_due_time;
+  if (ssl_context->GetCertifcateDueDate(cert_due_time)) {
+    if (crypto_manager_->IsCertificateUpdateRequired(cert_due_time)) {
+      NotifyOnCertififcateUpdateRequired();
+    }
   }
 
   if (ssl_context->IsInitCompleted()) {


### PR DESCRIPTION
Rework CryptoManager in order to handle certificate date on the fly
and to avoid certificate time caching, since it is possible to have
more then one certificate at one time point

Fix: SDLWIN-339

Substitude: #125 
