### PR TITLE
Pass assigner type to Pimpl

### DIFF
--- a/src/components/include/utils/pimpl.h
+++ b/src/components/include/utils/pimpl.h
@@ -45,19 +45,19 @@ namespace utils {
 template <typename Impl>
 class SwapAssigner {
  public:
-  void operator()(Impl* lhs, Impl* rhs) const;
+  void operator()(Impl& lhs, Impl& rhs) const;
 };
 
 template <typename Impl>
 class CopyAssigner {
  public:
-  void operator()(Impl* lhs, Impl* rhs) const;
+  void operator()(Impl& lhs, Impl& rhs) const;
 };
 
 template <typename Impl>
 class NonCopyAssigner {
  public:
-  void operator()(Impl* lhs, Impl* rhs) const;
+  void operator()(Impl& lhs, Impl& rhs) const;
 };
 
 /**

--- a/src/components/include/utils/pimpl.h
+++ b/src/components/include/utils/pimpl.h
@@ -38,7 +38,7 @@ namespace utils {
  * @brief Pimpls assigner
  *
  * Implements different approaches of Pimpls assignment
- * depend on required logic (swap, copy, non-copy)
+ * depend on required logic (swap, copy)
  *
  * @tparam Impl Type of Impl wrapped with Pimpl
  **/
@@ -50,12 +50,6 @@ class SwapAssigner {
 
 template <typename Impl>
 class CopyAssigner {
- public:
-  void operator()(Impl& lhs, Impl& rhs) const;
-};
-
-template <typename Impl>
-class NonCopyAssigner {
  public:
   void operator()(Impl& lhs, Impl& rhs) const;
 };

--- a/src/components/include/utils/pimpl.h
+++ b/src/components/include/utils/pimpl.h
@@ -35,6 +35,32 @@
 namespace utils {
 
 /**
+ * @brief Pimpls assigner
+ *
+ * Implements different approaches of Pimpls assignment
+ * depend on required logic (swap, copy, non-copy)
+ *
+ * @tparam Impl Type of Impl wrapped with Pimpl
+ **/
+template <typename Impl>
+class SwapAssigner {
+ public:
+  void operator()(Impl* lhs, Impl* rhs);
+};
+
+template <typename Impl>
+class CopyAssigner {
+ public:
+  void operator()(Impl* lhs, Impl* rhs);
+};
+
+template <typename Impl>
+class NonCopyAssigner {
+ public:
+  void operator()(Impl* lhs, Impl* rhs);
+};
+
+/**
  * @brief Pimpl
  *
  * Holds pointer to Impl object.
@@ -43,27 +69,23 @@ namespace utils {
  * Assignment and copying of Pimpl instance causes Impl pointers swapping.
  *
  * @tparam Impl Type of Impl to be wrapped
+ * @tparam Assigner Type of Assigner for Pimpl
  **/
-template <typename Impl>
+template <typename Impl, typename Assigner = SwapAssigner<Impl> >
 class Pimpl {
  public:
   Pimpl();
   Pimpl(Impl* impl);
-  Pimpl(Pimpl& rhs);
   ~Pimpl();
 
-  Pimpl& operator=(Pimpl& rhs);
+  Pimpl(const Pimpl& rhs);
+  Pimpl& operator=(const Pimpl& rhs);
+
   Impl* operator->() const;
   Impl& operator&() const;
 
  private:
   Impl* impl_;
-
-  /**
-   * @brief Swaps Impl pointers
-   * @param rhs Reference to Pimpl to be swapped with this
-   **/
-  void Swap(Pimpl& rhs);
 };
 
 }  // namespace utils

--- a/src/components/include/utils/pimpl.h
+++ b/src/components/include/utils/pimpl.h
@@ -45,19 +45,19 @@ namespace utils {
 template <typename Impl>
 class SwapAssigner {
  public:
-  void operator()(Impl* lhs, Impl* rhs);
+  void operator()(Impl* lhs, Impl* rhs) const;
 };
 
 template <typename Impl>
 class CopyAssigner {
  public:
-  void operator()(Impl* lhs, Impl* rhs);
+  void operator()(Impl* lhs, Impl* rhs) const;
 };
 
 template <typename Impl>
 class NonCopyAssigner {
  public:
-  void operator()(Impl* lhs, Impl* rhs);
+  void operator()(Impl* lhs, Impl* rhs) const;
 };
 
 /**
@@ -78,8 +78,8 @@ class Pimpl {
   Pimpl(Impl* impl);
   ~Pimpl();
 
-  Pimpl(const Pimpl& rhs);
-  Pimpl& operator=(const Pimpl& rhs);
+  Pimpl(Pimpl& rhs);
+  Pimpl& operator=(Pimpl& rhs);
 
   Impl* operator->() const;
   Impl& operator&() const;

--- a/src/components/include/utils/pimpl_impl.h
+++ b/src/components/include/utils/pimpl_impl.h
@@ -36,17 +36,17 @@
 #include <algorithm>
 
 template <typename Impl>
-void utils::SwapAssigner<Impl>::operator()(Impl* lhs, Impl* rhs) const {
+void utils::SwapAssigner<Impl>::operator()(Impl& lhs, Impl& rhs) const {
   std::swap(lhs, rhs);
 }
 
 template <typename Impl>
-void utils::CopyAssigner<Impl>::operator()(Impl* lhs, Impl* rhs) const {
-  *lhs = *rhs;
+void utils::CopyAssigner<Impl>::operator()(Impl& lhs, Impl& rhs) const {
+  lhs = rhs;
 }
 
 template <typename Impl>
-void utils::NonCopyAssigner<Impl>::operator()(Impl* lhs, Impl* rhs) const {
+void utils::NonCopyAssigner<Impl>::operator()(Impl& lhs, Impl& rhs) const {
   DCHECK_OR_RETURN_VOID(false);
 }
 
@@ -66,14 +66,14 @@ utils::Pimpl<Impl, Assigner>::~Pimpl() {
 template <typename Impl, typename Assigner>
 utils::Pimpl<Impl, Assigner>::Pimpl(utils::Pimpl<Impl, Assigner>& rhs) {
   Assigner assigner;
-  assigner(this->impl_, rhs.impl_);
+  assigner(*this->impl_, *rhs.impl_);
 }
 
 template <typename Impl, typename Assigner>
 utils::Pimpl<Impl, Assigner>& utils::Pimpl<Impl, Assigner>::operator=(
     utils::Pimpl<Impl, Assigner>& rhs) {
   Assigner assigner;
-  assigner(this->impl_, rhs.impl_);
+  assigner(*this->impl_, *rhs.impl_);
   return *this;
 }
 

--- a/src/components/include/utils/pimpl_impl.h
+++ b/src/components/include/utils/pimpl_impl.h
@@ -35,17 +35,18 @@
 #include "utils/pimpl.h"
 #include <algorithm>
 
-void utils::SwapAssigner<Impl>::operator()(Impl* lhs, Impl* rhs) {
+template <typename Impl>
+void utils::SwapAssigner<Impl>::operator()(Impl* lhs, Impl* rhs) const {
   std::swap(lhs, rhs);
 }
 
 template <typename Impl>
-void utils::CopyAssigner<Impl>::operator()(Impl* lhs, Impl* rhs) {
+void utils::CopyAssigner<Impl>::operator()(Impl* lhs, Impl* rhs) const {
   *lhs = *rhs;
 }
 
 template <typename Impl>
-void utils::NonCopyAssigner<Impl>::operator()(Impl* lhs, Impl* rhs) {
+void utils::NonCopyAssigner<Impl>::operator()(Impl* lhs, Impl* rhs) const {
   DCHECK_OR_RETURN_VOID(false);
 }
 
@@ -63,14 +64,14 @@ utils::Pimpl<Impl, Assigner>::~Pimpl() {
 }
 
 template <typename Impl, typename Assigner>
-utils::Pimpl<Impl, Assigner>::Pimpl(const utils::Pimpl<Impl, Assigner>& rhs) {
+utils::Pimpl<Impl, Assigner>::Pimpl(utils::Pimpl<Impl, Assigner>& rhs) {
   Assigner assigner;
   assigner(this->impl_, rhs.impl_);
 }
 
 template <typename Impl, typename Assigner>
 utils::Pimpl<Impl, Assigner>& utils::Pimpl<Impl, Assigner>::operator=(
-    const utils::Pimpl<Impl, Assigner>& rhs) {
+    utils::Pimpl<Impl, Assigner>& rhs) {
   Assigner assigner;
   assigner(this->impl_, rhs.impl_);
   return *this;

--- a/src/components/include/utils/pimpl_impl.h
+++ b/src/components/include/utils/pimpl_impl.h
@@ -35,43 +35,55 @@
 #include "utils/pimpl.h"
 #include <algorithm>
 
-template <typename Impl>
-utils::Pimpl<Impl>::Pimpl()
-    : impl_(new Impl()) {}
-
-template <typename Impl>
-utils::Pimpl<Impl>::Pimpl(Impl* impl)
-    : impl_(impl) {}
-
-template <typename Impl>
-utils::Pimpl<Impl>::Pimpl(utils::Pimpl<Impl>& rhs) {
-  Swap(rhs);
+void utils::SwapAssigner<Impl>::operator()(Impl* lhs, Impl* rhs) {
+  std::swap(lhs, rhs);
 }
 
 template <typename Impl>
-utils::Pimpl<Impl>::~Pimpl() {
+void utils::CopyAssigner<Impl>::operator()(Impl* lhs, Impl* rhs) {
+  *lhs = *rhs;
+}
+
+template <typename Impl>
+void utils::NonCopyAssigner<Impl>::operator()(Impl* lhs, Impl* rhs) {
+  DCHECK_OR_RETURN_VOID(false);
+}
+
+template <typename Impl, typename Assigner>
+utils::Pimpl<Impl, Assigner>::Pimpl()
+    : impl_(new Impl()) {}
+
+template <typename Impl, typename Assigner>
+utils::Pimpl<Impl, Assigner>::Pimpl(Impl* impl)
+    : impl_(impl) {}
+
+template <typename Impl, typename Assigner>
+utils::Pimpl<Impl, Assigner>::~Pimpl() {
   delete impl_;
 }
 
-template <typename Impl>
-utils::Pimpl<Impl>& utils::Pimpl<Impl>::operator=(utils::Pimpl<Impl>& rhs) {
-  Swap(rhs);
+template <typename Impl, typename Assigner>
+utils::Pimpl<Impl, Assigner>::Pimpl(const utils::Pimpl<Impl, Assigner>& rhs) {
+  Assigner assigner;
+  assigner(this->impl_, rhs.impl_);
+}
+
+template <typename Impl, typename Assigner>
+utils::Pimpl<Impl, Assigner>& utils::Pimpl<Impl, Assigner>::operator=(
+    const utils::Pimpl<Impl, Assigner>& rhs) {
+  Assigner assigner;
+  assigner(this->impl_, rhs.impl_);
   return *this;
 }
 
-template <typename Impl>
-Impl* utils::Pimpl<Impl>::operator->() const {
+template <typename Impl, typename Assigner>
+Impl* utils::Pimpl<Impl, Assigner>::operator->() const {
   return impl_;
 }
 
-template <typename Impl>
-Impl& utils::Pimpl<Impl>::operator&() const {
+template <typename Impl, typename Assigner>
+Impl& utils::Pimpl<Impl, Assigner>::operator&() const {
   return *impl_;
-}
-
-template <typename Impl>
-void utils::Pimpl<Impl>::Swap(utils::Pimpl<Impl>& rhs) {
-  std::swap(this->impl_, rhs.impl_);
 }
 
 #endif  // SRC_COMPONENTS_INCLUDE_UTILS_PIMPL_IMPL_H_

--- a/src/components/include/utils/pimpl_impl.h
+++ b/src/components/include/utils/pimpl_impl.h
@@ -45,11 +45,6 @@ void utils::CopyAssigner<Impl>::operator()(Impl& lhs, Impl& rhs) const {
   lhs = rhs;
 }
 
-template <typename Impl>
-void utils::NonCopyAssigner<Impl>::operator()(Impl& lhs, Impl& rhs) const {
-  DCHECK_OR_RETURN_VOID(false);
-}
-
 template <typename Impl, typename Assigner>
 utils::Pimpl<Impl, Assigner>::Pimpl()
     : impl_(new Impl()) {}


### PR DESCRIPTION
Current `Pimpl` class realization doesn't allow to choose copy&assign behavior. `Impl`s pointers swapping had been hardcoded as only available way. We have to extend `Pimpl` class with possibility to choose how it will copy&assign `Impl`s pointers. We have cases where we need `Pimpl`s with swap, copy and non-copy assignment policy. So this pull request provides such ability for `Pimpl` class by passing `Assigner` functor to `Pimpl` class as template parameter. Swap behavior will be kept as default to support present code
