### PR TITLE
Disable logging from policy dll (temporary)

### DIFF
--- a/src/components/policy/src/policy/src/policy_manager_impl.cc
+++ b/src/components/policy/src/policy/src/policy_manager_impl.cc
@@ -50,7 +50,7 @@ policy::PolicyManager* CreateManager(const std::string& app_storage_folder,
                                      uint16_t attempts_to_open_policy_db,
                                      uint16_t open_attempt_timeout_ms,
                                      logger::Logger::Pimpl& logger) {
-  SET_LOGGER(logger);
+  //SET_LOGGER(logger);
   return new policy::PolicyManagerImpl(
       app_storage_folder, attempts_to_open_policy_db, open_attempt_timeout_ms);
 }


### PR DESCRIPTION
Logging from Policy.dll causes a hanging on shutdown
because of dll unloading issue. Commit provides logger
transfer disabling between exe and dll to avoid described issue
