### PR TITLE
Do not deinit logger in destructor

### DIFF
--- a/src/components/policy/src/policy/src/policy_manager_impl.cc
+++ b/src/components/policy/src/policy/src/policy_manager_impl.cc
@@ -50,7 +50,7 @@ policy::PolicyManager* CreateManager(const std::string& app_storage_folder,
                                      uint16_t attempts_to_open_policy_db,
                                      uint16_t open_attempt_timeout_ms,
                                      logger::Logger::Pimpl& logger) {
-  //SET_LOGGER(logger);
+  SET_LOGGER(logger);
   return new policy::PolicyManagerImpl(
       app_storage_folder, attempts_to_open_policy_db, open_attempt_timeout_ms);
 }

--- a/src/components/utils/src/logger_posix.cc
+++ b/src/components/utils/src/logger_posix.cc
@@ -76,7 +76,6 @@ logger::Logger::Impl::Impl()
     , message_loop_thread_(NULL) {}
 
 logger::Logger::Impl::~Impl() {
-  DeinitLogger();
 }
 
 bool logger::Logger::Impl::InitLogger(const bool logs_enabled,

--- a/src/components/utils/src/logger_qt.cc
+++ b/src/components/utils/src/logger_qt.cc
@@ -97,7 +97,6 @@ logger::Logger::Impl::Impl()
     , message_loop_thread_(NULL) {}
 
 logger::Logger::Impl::~Impl() {
-  DeinitLogger();
 }
 
 bool logger::Logger::Impl::InitLogger(const bool logs_enabled,

--- a/src/components/utils/src/logger_win.cc
+++ b/src/components/utils/src/logger_win.cc
@@ -77,7 +77,6 @@ logger::Logger::Impl::Impl()
     , message_loop_thread_(NULL) {}
 
 logger::Logger::Impl::~Impl() {
-  DeinitLogger();
 }
 
 bool logger::Logger::Impl::InitLogger(const bool logs_enabled,


### PR DESCRIPTION
Remove logger deinitialization from destructor
to avoid double deleting in logger's copy

Restore logger setting in policy
