### PR TITLE
Remove spamming auto trace log

### DIFF
--- a/src/components/utils/src/socket_posix.cc
+++ b/src/components/utils/src/socket_posix.cc
@@ -176,7 +176,6 @@ bool utils::TcpSocketConnection::Impl::CreateNotifictionPipes() {
 bool utils::TcpSocketConnection::Impl::Send(const char* buffer,
                                             const std::size_t size,
                                             std::size_t& bytes_written) {
-  LOGGER_AUTO_TRACE(logger_);
   bytes_written = 0u;
   if (!IsValid()) {
     LOGGER_ERROR(logger_, "Failed to send data socket is not valid");

--- a/src/components/utils/src/socket_win.cc
+++ b/src/components/utils/src/socket_win.cc
@@ -157,7 +157,6 @@ utils::TcpSocketConnection::Impl::~Impl() {
 bool utils::TcpSocketConnection::Impl::Send(const char* const buffer,
                                             std::size_t size,
                                             std::size_t& bytes_written) {
-  LOGGER_AUTO_TRACE(logger_);
   bytes_written = 0u;
   if (!IsValid()) {
     LOGGER_ERROR(logger_, "Failed to send data socket is not valid");


### PR DESCRIPTION
In case of `WOULD_BLOCK` socket error we'll call `Send` again and again till success and get auto trace log on each call
