### PR TITLE
Use Queued connection for Qt socket notify signal

### DIFF
--- a/src/components/transport_manager/src/transport_adapter/threaded_socket_connection.cc
+++ b/src/components/transport_manager/src/transport_adapter/threaded_socket_connection.cc
@@ -160,7 +160,7 @@ void ThreadedSocketConnection::Transmit() {
 
 void ThreadedSocketConnection::Send() {
   LOGGER_AUTO_TRACE(logger_);
-  LOGGER_DEBUG(logger_, "Trying to send data if awailable");
+  LOGGER_DEBUG(logger_, "Trying to send data if available");
   FrameQueue frames_to_send;
   {
     sync_primitives::AutoLock auto_lock(frames_to_send_mutex_);

--- a/src/components/utils/src/socket_qt.cc
+++ b/src/components/utils/src/socket_qt.cc
@@ -303,7 +303,7 @@ void utils::TcpSocketConnection::Impl::InitSocketSignals() {
           SIGNAL(NotifySignal()),
           loop_.data(),
           SLOT(quit()),
-          Qt::DirectConnection);
+          Qt::QueuedConnection);
 }
 
 void utils::TcpSocketConnection::Impl::Wait() {


### PR DESCRIPTION
Replace Qt::DirectConnection with Qt::QueuedConnection
to get ability to process notify signal emitted until
event loop has not been started.

With current implementation we can not send data while
socket read/write operation is in progress.

Resolves [SDLWIN-365](https://adc.luxoft.com/jira/browse/SDLWIN-365)
