### PR TITLE
Extract business logic out of the DCHECK

### DIFF
--- a/src/components/application_manager/src/message_helper.cc
+++ b/src/components/application_manager/src/message_helper.cc
@@ -2099,12 +2099,14 @@ void MessageHelper::SendSystemRequestNotification(
 
   (*content)[strings::params][strings::connection_key] = connection_key;
 
-  smart_objects::SmartObject* so = new smart_objects::SmartObject(*content);
+  commands::MessageSharedPtr message =
+      utils::MakeShared<smart_objects::SmartObject>(*content);
 #ifdef DEBUG
-  PrintSmartObject(*so);
+  PrintSmartObject(*message);
 #endif
-
-  DCHECK(ApplicationManagerImpl::instance()->ManageMobileCommand(so));
+  const bool handled =
+      ApplicationManagerImpl::instance()->ManageMobileCommand(message);
+  DCHECK(handled);
 }
 
 void MessageHelper::SendLaunchApp(uint32_t connection_key,


### PR DESCRIPTION
Issue [SDLWIN-392](https://adc.luxoft.com/jira/browse/SDLWIN-392)

Don't pass the raw pointer to the ManageMobileCommand.
This method create shared_ptr implicitly.
DCHECK executes `condition` twice when it's false. Thus
there will be two shared pointers pointing to the same
raw pointer.

@anosach-luxoft, @nk0leg, @OHerasym please review.
