### PR TITLE
Fix null field validation in the policy 

### DIFF
--- a/src/components/rpc_base/include/rpc_base/rpc_base_inl.h
+++ b/src/components/rpc_base/include/rpc_base/rpc_base_inl.h
@@ -503,11 +503,6 @@ Nullable<T>::Nullable()
 
 template <typename T>
 template <typename U>
-Nullable<T>::Nullable(const U& value)
-    : T(value), marked_null_(false) {}
-
-template <typename T>
-template <typename U>
 Nullable<T>& Nullable<T>::operator=(const U& new_val) {
   this->T::operator=(new_val);
   return *this;
@@ -615,11 +610,6 @@ void rpc::Optional<T>::SetPolicyTableType(
 template <typename T>
 Stringifyable<T>::Stringifyable()
     : predefined_string_("") {}
-
-template <typename T>
-template <typename U>
-Stringifyable<T>::Stringifyable(const U& value)
-    : T(value), predefined_string_("") {}
 
 template <typename T>
 template <typename U>

--- a/src/components/utils/CMakeLists.txt
+++ b/src/components/utils/CMakeLists.txt
@@ -54,6 +54,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
                 ${UTILS_INCLUDE_DIR}/utils/host_address.h
                 ${UTILS_INCLUDE_DIR}/utils/socket.h
                 ${UTILS_INCLUDE_DIR}/utils/socket_utils.h
+                ${UTILS_INCLUDE_DIR}/utils/type_traits.h
                 )
 
       set (src ${UTILS_SRC_DIR}/bitstream.cc

--- a/src/components/utils/include/utils/json_utils.h
+++ b/src/components/utils/include/utils/json_utils.h
@@ -551,7 +551,8 @@ inline bool JsonValue::IsString() const {
 }
 
 inline bool JsonValue::IsObject() const {
-  return Type() == ValueType::OBJECT_VALUE;
+  const ValueType::Type type = Type();
+  return type == ValueType::NULL_VALUE || type == ValueType::OBJECT_VALUE;
 }
 
 inline bool JsonValue::IsNull() const {
@@ -559,7 +560,8 @@ inline bool JsonValue::IsNull() const {
 }
 
 inline bool JsonValue::IsArray() const {
-  return Type() == ValueType::ARRAY_VALUE;
+  const ValueType::Type type = Type();
+  return type == ValueType::NULL_VALUE || type == ValueType::ARRAY_VALUE;
 }
 
 inline JsonValue::iterator JsonValue::begin() {

--- a/src/components/utils/include/utils/type_traits.h
+++ b/src/components/utils/include/utils/type_traits.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2016, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef SRC_COMPONENTS_UTILS_INCLUDE_UTILS_TYPE_TRAITS_H_
+#define SRC_COMPONENTS_UTILS_INCLUDE_UTILS_TYPE_TRAITS_H_
+
+namespace utils {
+namespace type_traits {
+
+typedef char(&yes)[1];
+typedef char(&no)[2];
+
+template <typename Base, typename Derived>
+struct Host {
+  operator Base*() const;
+  operator Derived*();
+};
+
+template <typename Base, typename Derived>
+struct is_base_of {
+  template <typename T>
+  static yes check(Derived*, T);
+  static no check(Base*, int);
+
+  static const bool value =
+      sizeof(check(Host<Base, Derived>(), int())) == sizeof(yes);
+};
+
+template <bool B, class T = void>
+struct enable_if {};
+
+template <class T>
+struct enable_if<true, T> {
+  typedef T type;
+};
+
+}  // namespace type_traits
+}  // namespace utils
+
+#endif  // SRC_COMPONENTS_UTILS_INCLUDE_UTILS_TYPE_TRAITS_H_


### PR DESCRIPTION
Issue [SDLWIN-382](https://adc.luxoft.com/jira/browse/SDLWIN-382)

There are two problems:
- qt wrapper didn't treat null as object and as array. jsoncpp (and the sdl) works this way, thus there was different logic.
- VS2010 (which is used with Qt) calls the copy constructor, which resets null flag on inserting data into the map.
