### PR TITLE
Fix high cpu usage in the bluetooth scanner

### DIFF
--- a/src/components/transport_manager/include/transport_manager/bluetooth/bluetooth_transport_adapter.h
+++ b/src/components/transport_manager/include/transport_manager/bluetooth/bluetooth_transport_adapter.h
@@ -73,6 +73,9 @@ class BluetoothTransportAdapter : public TransportAdapterImpl {
    * @return True on success false otherwise
    */
   virtual bool Restore();
+
+ private:
+  static const int kDeviceRepeatSearchIntervalSec = 1;
 };
 
 }  // namespace transport_adapter

--- a/src/components/transport_manager/src/bluetooth/bluetooth_device_scanner_posix.cc
+++ b/src/components/transport_manager/src/bluetooth/bluetooth_device_scanner_posix.cc
@@ -413,15 +413,12 @@ void BluetoothDeviceScanner::Thread() {
       TimedWaitForDeviceScanRequest();
     }
   } else {  // search only on demand
-    while (true) {
+    while (!shutdown_requested_) {
       {
         sync_primitives::AutoLock auto_lock(device_scan_requested_lock_);
         while (!(device_scan_requested_ || shutdown_requested_)) {
           device_scan_requested_cv_.Wait(auto_lock);
         }
-      }
-      if (shutdown_requested_) {
-        break;
       }
       DoInquiry();
       device_scan_requested_ = false;

--- a/src/components/transport_manager/src/bluetooth/bluetooth_device_scanner_win.cc
+++ b/src/components/transport_manager/src/bluetooth/bluetooth_device_scanner_win.cc
@@ -176,7 +176,7 @@ void BluetoothDeviceScanner::DoInquiry() {
     controller_->FindNewApplicationsRequest();
   }
   if (found_devices.empty()) {
-    LOGGER_DEBUG(logger_, "number_of_devices < 0");
+    LOGGER_DEBUG(logger_, "No devices were found");
     controller_->SearchDeviceFailed(SearchDeviceError());
   }
 }
@@ -361,15 +361,12 @@ void BluetoothDeviceScanner::Thread() {
       TimedWaitForDeviceScanRequest();
     }
   } else {  // search only on demand
-    while (true) {
+    while (!shutdown_requested_) {
       {
         sync_primitives::AutoLock auto_lock(device_scan_requested_lock_);
         while (!(device_scan_requested_ || shutdown_requested_)) {
           device_scan_requested_cv_.Wait(auto_lock);
         }
-      }
-      if (shutdown_requested_) {
-        break;
       }
       DoInquiry();
       device_scan_requested_ = false;

--- a/src/components/transport_manager/src/bluetooth/bluetooth_transport_adapter_posix.cc
+++ b/src/components/transport_manager/src/bluetooth/bluetooth_transport_adapter_posix.cc
@@ -59,9 +59,13 @@ CREATE_LOGGERPTR_GLOBAL(logger_, "TransportManager")
 BluetoothTransportAdapter::~BluetoothTransportAdapter() {}
 
 BluetoothTransportAdapter::BluetoothTransportAdapter()
-    : TransportAdapterImpl(new BluetoothDeviceScanner(this, true, 0),
-                           new BluetoothConnectionFactory(this),
-                           0) {}
+    : TransportAdapterImpl(
+          new BluetoothDeviceScanner(
+              this,
+              true,
+              BluetoothTransportAdapter::kDeviceRepeatSearchIntervalSec),
+          new BluetoothConnectionFactory(this),
+          0) {}
 
 DeviceType BluetoothTransportAdapter::GetDeviceType() const {
   return BLUETOOTH;

--- a/src/components/transport_manager/src/bluetooth/bluetooth_transport_adapter_win.cc
+++ b/src/components/transport_manager/src/bluetooth/bluetooth_transport_adapter_win.cc
@@ -59,9 +59,13 @@ namespace transport_adapter {
 CREATE_LOGGERPTR_GLOBAL(logger_, "TransportManager")
 
 BluetoothTransportAdapter::BluetoothTransportAdapter()
-    : TransportAdapterImpl(new BluetoothDeviceScanner(this, true, 0),
-                           new BluetoothConnectionFactory(this),
-                           0) {}
+    : TransportAdapterImpl(
+          new BluetoothDeviceScanner(
+              this,
+              true,
+              BluetoothTransportAdapter::kDeviceRepeatSearchIntervalSec),
+          new BluetoothConnectionFactory(this),
+          0) {}
 
 BluetoothTransportAdapter::~BluetoothTransportAdapter() {}
 


### PR DESCRIPTION
Zero delay causes some kind of "spin lock" since
BluetoothDeviceScanner::TimedWaitForDeviceScanRequest will exit without
any delay. One second timeout is quite small and it shouldn't
cause huge impact to the user experience.

@anosach-luxoft, @nk0leg, please review.
