### PR TITLE
Fix/use db for resumption

### DIFF
--- a/src/components/application_manager/src/resumption/resumption_data_db.cc
+++ b/src/components/application_manager/src/resumption/resumption_data_db.cc
@@ -473,8 +473,8 @@ bool ResumptionDataDB::CheckExistenceHMIId(uint32_t hmi_app_id) const {
       return true;
     }
   }
-  LOGGER_FATAL(logger_,
-               "HMI appID = " << hmi_app_id << " doesn't exist in saved data");
+  LOGGER_DEBUG(logger_,
+    "HMI appID = " << hmi_app_id << " doesn't exist in saved data");
   return false;
 }
 

--- a/src/components/utils/include/utils/sql_qt_wrapper/sql_database.h
+++ b/src/components/utils/include/utils/sql_qt_wrapper/sql_database.h
@@ -16,8 +16,8 @@ namespace dbms {
  */
 class SQLDatabase {
  public:
-  SQLDatabase();
-  explicit SQLDatabase(const std::string& filename);
+  SQLDatabase(const std::string& database_path,
+              const std::string& connection_name);
   ~SQLDatabase();
 
   /**
@@ -63,12 +63,6 @@ class SQLDatabase {
   bool HasErrors() const;
 
   /**
-   * Sets path to database
-   * If the database is already opened then need reopen it
-   */
-  void set_path(const std::string& path);
-
-  /**
    * @brief get_path databse location path.
    *
    * @return the path to the database location
@@ -88,41 +82,23 @@ class SQLDatabase {
 
   operator QSqlDatabase() const;
 
- protected:
  private:
   QSqlDatabase db_;
-  /**
-   * Lock for guarding connection to database
-   */
-  sync_primitives::Lock conn_lock_;
 
   /**
    * The filename of database
    */
-  std::string databasename_;
+  const QString database_path_;
 
   /**
-   * The last error that occurred on the database
+   * The database connection name
    */
-  int error_;
+  const QString connection_name_;
 
   /**
-   *  The temporary in-memory database
-   *  @see SQLite manual
+   * Lock for guarding connection to database
    */
-  static const std::string kInMemory;
-
-  /**
-   * The extension of filename of database
-   */
-  static const std::string kExtension;
-
-  /**
-   * Execs query for internal using in this class
-   * @param query sql query without return results
-   * @return true if query was executed successfully
-   */
-  inline bool Exec(const std::string& query);
+  mutable sync_primitives::Lock conn_lock_;
 };
 
 }  // namespace dbms

--- a/src/components/utils/include/utils/sql_qt_wrapper/sql_query.h
+++ b/src/components/utils/include/utils/sql_qt_wrapper/sql_query.h
@@ -33,9 +33,10 @@
 #ifndef SRC_COMPONENTS_POLICY_SQLITE_WRAPPER_INCLUDE_SQL_QT_WRAPPER_SQL_QUERY_H_
 #define SRC_COMPONENTS_POLICY_SQLITE_WRAPPER_INCLUDE_SQL_QT_WRAPPER_SQL_QUERY_H_
 
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 
+#include <QStringList>
 #include <QSqlQuery>
 
 #include "utils/lock.h"
@@ -202,7 +203,15 @@ class SQLQuery {
   SQLError LastError() const;
 
  private:
+  /**
+   * @brief Splits query by statements
+   * @param query Query to be processed
+   * @return List of query statements
+   */
+  QStringList SplitQuery(const std::string& query) const;
+
   QSqlQuery query_;
+  QStringList queries_cache_;
 };
 
 }  // namespace dbms

--- a/src/components/utils/include/utils/sqlite_wrapper/sql_database.h
+++ b/src/components/utils/include/utils/sqlite_wrapper/sql_database.h
@@ -49,8 +49,8 @@ class SQLQuery;
  */
 class SQLDatabase {
  public:
-  SQLDatabase();
-  explicit SQLDatabase(const std::string& filename);
+  SQLDatabase(const std::string& database_path,
+              const std::string& connection_name);
   ~SQLDatabase();
 
   /**
@@ -96,12 +96,6 @@ class SQLDatabase {
   bool HasErrors() const;
 
   /**
-   * Sets path to database
-   * If the database is already opened then need reopen it
-   */
-  void set_path(const std::string& path);
-
-  /**
    * @brief get_path databse location path.
    *
    * @return the path to the database location
@@ -144,11 +138,13 @@ class SQLDatabase {
   /**
    * The filename of database
    */
-  std::string databasename_;
+  const std::string database_path_;
 
   /**
-   * The last error that occurred on the database
+   * The database connection name
    */
+  const std::string connection_name_;
+
   int error_;
 
   /**

--- a/src/components/utils/src/sqlite_wrapper/sql_database.cc
+++ b/src/components/utils/src/sqlite_wrapper/sql_database.cc
@@ -39,11 +39,12 @@ namespace dbms {
 const std::string SQLDatabase::kInMemory = ":memory:";
 const std::string SQLDatabase::kExtension = ".sqlite";
 
-SQLDatabase::SQLDatabase()
-    : conn_(NULL), databasename_(kInMemory), error_(SQLITE_OK) {}
-
-SQLDatabase::SQLDatabase(const std::string& db_name)
-    : conn_(NULL), databasename_(db_name + kExtension), error_(SQLITE_OK) {}
+SQLDatabase::SQLDatabase(const std::string& database_path,
+                         const std::string& connection_name)
+    : conn_(NULL)
+    , database_path_(database_path + kExtension)
+    , connection_name_(connection_name)
+    , error_(SQLITE_OK) {}
 
 SQLDatabase::~SQLDatabase() {
   Close();
@@ -53,7 +54,7 @@ bool SQLDatabase::Open() {
   sync_primitives::AutoLock auto_lock(conn_lock_);
   if (conn_)
     return true;
-  error_ = sqlite3_open(databasename_.c_str(), &conn_);
+  error_ = sqlite3_open(database_path_.c_str(), &conn_);
   return error_ == SQLITE_OK;
   return true;
 }
@@ -106,12 +107,8 @@ sqlite3* SQLDatabase::conn() const {
   return conn_;
 }
 
-void SQLDatabase::set_path(const std::string& path) {
-  databasename_ = path + databasename_;
-}
-
 std::string SQLDatabase::get_path() const {
-  return databasename_;
+  return database_path_;
 }
 
 bool SQLDatabase::Backup() {


### PR DESCRIPTION
Current changes is related to defect SDLWIN-381.
By default QT logger in logging level FATAL abort program and show
assertion windows. It's wrong behaviour, current method
must just log executing result in file.
Besides, there is no any reason in FATAL log level, current
method can't know is this situation critical or not.

Related:
        [SDLWIN-381](https://adc.luxoft.com/jira/browse/SDLWIN-381)
